### PR TITLE
fix: Windows PATH detection in doctor/init + docs/config page (#43, #44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,44 @@ jobs:
           npm install -g "$($tarball.FullName)"
           sverklo --version
 
+      # Regression test for issue #43: `sverklo doctor` must find the
+      # binary on PATH cross-platform. The previous `command -v` approach
+      # broke on Windows because cmd.exe has no `command` builtin.
+      # We assert the output does NOT contain the regression strings.
+      - name: sverklo doctor regression check (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p /tmp/sverklo-doctor-test && cd /tmp/sverklo-doctor-test
+          set +e
+          out=$(sverklo doctor 2>&1)
+          echo "$out"
+          if echo "$out" | grep -qi "sverklo binary not found on PATH"; then
+            echo "::error::issue #43 regression: doctor reports binary not on PATH"
+            exit 1
+          fi
+          if echo "$out" | grep -qi "is not recognized as an internal"; then
+            echo "::error::issue #43 regression: shell error leaked from doctor"
+            exit 1
+          fi
+
+      - name: sverklo doctor regression check (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\sverklo-doctor-test | Out-Null
+          Set-Location C:\sverklo-doctor-test
+          $out = sverklo doctor 2>&1 | Out-String
+          Write-Host $out
+          if ($out -match "sverklo binary not found on PATH") {
+            Write-Host "::error::issue #43 regression: doctor reports binary not on PATH"
+            exit 1
+          }
+          if ($out -match "is not recognized as an internal") {
+            Write-Host "::error::issue #43 regression: shell error leaked from doctor"
+            exit 1
+          }
+
   install-published:
     # Schedule-only. Installs the published sverklo@latest from npm to catch
     # regressions where a transitive dep changes prebuild availability without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [0.22.1] — 2026-05-18
+
+### Fixed
+
+- **#43 — Windows: `sverklo doctor` / `sverklo init` falsely reported "binary not found on PATH"**. Three call sites were shelling out to `command -v sverklo`, which is POSIX-only. On Windows cmd.exe printed `'command' is not recognized as an internal or external command` twice and we surfaced a misleading "not found" status even though `sverklo --version` worked from the same shell. Replaced with a cross-platform `findOnPath` helper that walks `PATH` directly with no shell dependency.
+- **#44 — broken `https://sverklo.com/docs/config` link** in `sverklo init`'s footer tip. The page now exists with the full `.sverklo.yaml` schema, including the most-asked-for recipe: how to exclude directories in a monorepo.
+
+### CI
+
+- New regression guard in `install-smoke`: every PR now runs `sverklo doctor` on Windows + macOS + Linux and asserts the output doesn't contain the issue-#43 strings. The original v0.22.0 ship would have been blocked by this gate.
+
+---
+
 ## [0.22.0] — 2026-05-17
 
 ### Added

--- a/bin/sverklo.ts
+++ b/bin/sverklo.ts
@@ -728,12 +728,11 @@ if (command === "setup" || command === "install") {
     const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import("node:fs");
     const { join } = await import("node:path");
     const { homedir } = await import("node:os");
-    const { execSync } = await import("node:child_process");
+    const { findOnPath } = await import("../src/utils/find-on-path.js");
 
-    let sverkloBin = "sverklo";
-    try {
-      sverkloBin = execSync("command -v sverklo", { encoding: "utf-8" }).trim() || "sverklo";
-    } catch {}
+    // Issue #43: `command -v` is POSIX-only and printed misleading
+    // errors on Windows. Walk PATH cross-platform instead.
+    const sverkloBin = findOnPath("sverklo") ?? "sverklo";
 
     // Claude Code global settings: ~/.claude/settings.json
     const claudeSettingsDir = join(homedir(), ".claude");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sverklo",
   "mcpName": "io.github.sverklo/sverklo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Local-first code intelligence — MCP server for Claude Code, Cursor, Windsurf, Zed. Symbol graph, blast-radius, git-pinned memory. 43× fewer tokens than naive grep on the public bench. MIT, zero-config.",
   "type": "module",
   "bin": {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,9 +1,10 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { execSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { track } from "./telemetry/index.js";
+import { findOnPath } from "./utils/find-on-path.js";
 
 /**
  * Read the version from the package.json bundled with the running
@@ -43,15 +44,18 @@ export function runDoctor(projectPath: string): void {
   let mcpEnvFromConfig: Record<string, string> | undefined;
 
   // 1. Binary on PATH
-  let sverkloBin: string | null = null;
-  try {
-    sverkloBin = execSync("command -v sverklo", { encoding: "utf-8" }).trim();
+  // Cross-platform PATH lookup. Earlier versions shelled out to
+  // `command -v sverklo`, which is POSIX-only — on Windows cmd.exe
+  // printed "'command' is not recognized" and we surfaced a misleading
+  // "binary not found" (issue #43).
+  let sverkloBin: string | null = findOnPath("sverklo");
+  if (sverkloBin) {
     checks.push({
       name: "sverklo binary",
       status: "ok",
       message: sverkloBin,
     });
-  } catch {
+  } else {
     // Before recommending a global install, check whether sverklo is
     // already present locally (in node_modules/.bin). Telling someone
     // who just ran `npm install sverklo` to also run `npm install -g`

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, readdirSync } from "node:fs";
-import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { track, hasBeenNudged, markNudged } from "./telemetry/index.js";
+import { findOnPath } from "./utils/find-on-path.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -262,13 +262,14 @@ export function detectCopilotExtension(): boolean {
  * Resolve the absolute path to the sverklo binary.
  * Using a full path is more reliable than relying on PATH inheritance
  * when Claude Code spawns the subprocess.
+ *
+ * Issue #43: earlier versions used `command -v` here, which is
+ * POSIX-only. On Windows cmd.exe surfaced "'command' is not
+ * recognized" and we fell back to a bare "sverklo" string that the
+ * host couldn't resolve. We now walk PATH ourselves cross-platform.
  */
 function resolveSverkloBinary(): string {
-  try {
-    return execSync("command -v sverklo", { encoding: "utf-8" }).trim() || "sverklo";
-  } catch {
-    return "sverklo";
-  }
+  return findOnPath("sverklo") ?? "sverklo";
 }
 
 function buildAutoCaptureHook() {

--- a/src/utils/find-on-path.test.ts
+++ b/src/utils/find-on-path.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findOnPath } from "./find-on-path.js";
+
+describe("findOnPath", () => {
+  let tmp: string;
+  let origPath: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "find-path-test-"));
+    origPath = process.env.PATH;
+  });
+
+  afterEach(() => {
+    process.env.PATH = origPath;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("finds a binary that exists on PATH", () => {
+    const bin = join(tmp, "tooly");
+    writeFileSync(bin, "#!/bin/sh\necho hi\n");
+    if (process.platform !== "win32") chmodSync(bin, 0o755);
+    process.env.PATH = tmp;
+    expect(findOnPath("tooly")).toBe(bin);
+  });
+
+  it("returns null when binary is not on PATH", () => {
+    process.env.PATH = tmp;
+    expect(findOnPath("definitely-not-here")).toBeNull();
+  });
+
+  it("returns null on empty PATH", () => {
+    process.env.PATH = "";
+    expect(findOnPath("ls")).toBeNull();
+  });
+
+  it("searches multiple PATH directories", () => {
+    const a = join(tmp, "a");
+    const b = join(tmp, "b");
+    mkdirSync(a);
+    mkdirSync(b);
+    const bin = join(b, "tooly");
+    writeFileSync(bin, "#!/bin/sh\n");
+    if (process.platform !== "win32") chmodSync(bin, 0o755);
+    process.env.PATH = `${a}${process.platform === "win32" ? ";" : ":"}${b}`;
+    expect(findOnPath("tooly")).toBe(bin);
+  });
+
+  it("handles Windows .cmd extension lookups", () => {
+    if (process.platform !== "win32") {
+      // POSIX has no .cmd extension semantics — this test confirms
+      // we don't accidentally invent matches by appending random
+      // extensions there.
+      writeFileSync(join(tmp, "tooly.cmd"), "");
+      process.env.PATH = tmp;
+      expect(findOnPath("tooly")).toBeNull();
+      return;
+    }
+    writeFileSync(join(tmp, "tooly.cmd"), "");
+    process.env.PATH = tmp;
+    expect(findOnPath("tooly")).toBe(join(tmp, "tooly.cmd"));
+  });
+
+  it("ignores empty PATH segments", () => {
+    process.env.PATH = `::${tmp}`;
+    const bin = join(tmp, "tooly");
+    writeFileSync(bin, "#!/bin/sh\n");
+    if (process.platform !== "win32") chmodSync(bin, 0o755);
+    expect(findOnPath("tooly")).toBe(bin);
+  });
+});

--- a/src/utils/find-on-path.test.ts
+++ b/src/utils/find-on-path.test.ts
@@ -64,9 +64,10 @@ describe("findOnPath", () => {
   });
 
   it("ignores empty PATH segments", () => {
-    process.env.PATH = `::${tmp}`;
-    const bin = join(tmp, "tooly");
-    writeFileSync(bin, "#!/bin/sh\n");
+    const sep = process.platform === "win32" ? ";" : ":";
+    process.env.PATH = `${sep}${sep}${tmp}`;
+    const bin = join(tmp, process.platform === "win32" ? "tooly.cmd" : "tooly");
+    writeFileSync(bin, process.platform === "win32" ? "" : "#!/bin/sh\n");
     if (process.platform !== "win32") chmodSync(bin, 0o755);
     expect(findOnPath("tooly")).toBe(bin);
   });

--- a/src/utils/find-on-path.ts
+++ b/src/utils/find-on-path.ts
@@ -1,0 +1,30 @@
+import { statSync } from "node:fs";
+import { join } from "node:path";
+
+// Cross-platform replacement for `command -v <name>` (POSIX) and
+// `where <name>` (Windows). Walks PATH ourselves to avoid any shell
+// dependency — issue #43 was a Windows regression because `command -v`
+// is not a cmd.exe builtin and printed a confusing error there.
+//
+// On Windows we also try PATHEXT-style extensions (.cmd is the common
+// one for npm-installed bins). The first match wins.
+export function findOnPath(name: string): string | null {
+  const isWin = process.platform === "win32";
+  const sep = isWin ? ";" : ":";
+  const exts = isWin
+    ? ["", ".cmd", ".exe", ".bat", ".ps1"]
+    : [""];
+  const dirs = (process.env.PATH ?? "").split(sep);
+  for (const dir of dirs) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = join(dir, name + ext);
+      try {
+        if (statSync(candidate).isFile()) return candidate;
+      } catch {
+        // not a file or permission denied — keep walking
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes both issues filed by @nviraj today, day-1 of v0.22.0.

## Closes #43 — `sverklo doctor` / `sverklo init` false-negative on Windows

Three call sites shelled out to \`command -v sverklo\` to detect the binary on PATH. That's POSIX-only — Windows cmd.exe printed \`'command' is not recognized as an internal or external command\` twice and we surfaced a misleading \`✗ sverklo binary not found on PATH\` status, even though \`sverklo --version\` worked from the same shell.

**Fix**: new \`src/utils/find-on-path.ts\` walks PATH ourselves cross-platform with no shell dependency. Handles Windows extension semantics (.cmd / .exe / .bat / .ps1).

Wired into all three sites:
- \`src/doctor.ts\` line 48
- \`src/init.ts\` \`resolveSverkloBinary()\` line 268
- \`bin/sverklo.ts\` Claude settings setup line 735

Also dropped the now-unused \`execSync\` imports in doctor.ts and init.ts.

### New CI regression gate

Per Constitution Principle IV.4 (user-reported failures must become CI gates, not just code fixes): every PR now runs \`sverklo doctor\` on Windows + macOS + Linux and asserts the output doesn't contain the regression strings. The original v0.22.0 release would have been blocked by this gate.

## Closes #44 — broken \`https://sverklo.com/docs/config\` link

The \`sverklo init\` end-of-flow tip pointed at a 404. Two-part fix:

1. **Sverklo-site**: new page at \`sverklo-site/docs/config/index.html\` with the full \`.sverklo.yaml\` schema (ignore, weights, search, indexing.extensions, embeddings) and the most-asked recipe — how to exclude directories in a monorepo. Ships in a separate sverklo-site commit.
2. **No source change in sverklo**: the URL in \`init.ts\` was already correct (\`/docs/config\`); we just needed to make the destination exist.

## Test plan

- [x] Local: \`sverklo doctor\` finds binary cleanly (\`/opt/homebrew/bin/sverklo\` on macOS)
- [x] Local: full vitest run — 631/632 passing (+6 findOnPath unit tests)
- [ ] CI: 3 \`test\` cells + 3 \`install-smoke\` cells (existing) + 3 NEW \`doctor regression check\` steps must all pass

## Version

Bumped to **v0.22.1** — patch (one-class bug fix, no API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)