### PR TITLE
fix: Windows MCP probe false-negative + sverklo list stale time (#47, #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [0.22.2] — 2026-05-19
+
+### Fixed
+
+- **#47 — Windows: `sverklo doctor` MCP probe reported false-negative even though Claude Code could connect.** The probe spawned `sverklo` directly via `spawnSync` with stdio piping, which broke on Windows when the resolved path was an npm `.cmd` shim — Node CVE-2024-27980's argument-escape tightening (Aug 2024) makes that fail with `EINVAL`. Fix: detect Windows `.cmd`/`.bat` shims and launch via shell. POSIX path unchanged.
+- **#49 — `sverklo list` showed stale "last indexed" time.** The registry's `lastIndexed` field was set on `register` but `updateLastIndexed` was never called outside tests, so subsequent reindexes didn't update it. `sverklo list` now derives the timestamp from the actual `.sverklo/*.db` mtime per registered repo (falling back to the registry stamp if the project isn't accessible).
+- **#48 — `/docs/config` clarification** (sverklo-site): documented that <em>last match wins</em> when multiple `weights` globs match a file. Example shows ordering's impact.
+
+---
+
 ## [0.22.1] — 2026-05-18
 
 ### Fixed

--- a/bin/sverklo.ts
+++ b/bin/sverklo.ts
@@ -238,9 +238,26 @@ if (command === "list") {
   } else {
     console.log(`Registered repositories (${entries.length}):`);
     console.log("");
+    const { statSync, existsSync } = await import("node:fs");
+    const { getProjectConfig } = await import("../src/utils/config.js");
     const now = Date.now();
     for (const [name, entry] of entries) {
-      const age = now - new Date(entry.lastIndexed).getTime();
+      // Issue #49: the registry's `lastIndexed` is set on `register`
+      // but never updated after subsequent reindexes, so it was
+      // showing a stale time. The actual index db's mtime is the
+      // correct source of truth — derive from there if it exists,
+      // otherwise fall back to the registry stamp.
+      let timestamp = new Date(entry.lastIndexed).getTime();
+      try {
+        const cfg = getProjectConfig(entry.path);
+        if (existsSync(cfg.dbPath)) {
+          timestamp = statSync(cfg.dbPath).mtimeMs;
+        }
+      } catch {
+        // Project path may not be accessible from here — keep the
+        // registry stamp as the fallback.
+      }
+      const age = now - timestamp;
       const ageStr = age < 60_000 ? `${Math.floor(age / 1000)}s ago`
         : age < 3_600_000 ? `${Math.floor(age / 60_000)} min ago`
         : age < 86_400_000 ? `${Math.floor(age / 3_600_000)} hours ago`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sverklo",
   "mcpName": "io.github.sverklo/sverklo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Local-first code intelligence — MCP server for Claude Code, Cursor, Windsurf, Zed. Symbol graph, blast-radius, git-pinned memory. 43× fewer tokens than naive grep on the public bench. MIT, zero-config.",
   "type": "module",
   "bin": {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -502,12 +502,21 @@ export function runDoctor(projectPath: string): void {
         .join("\n") + "\n";
 
     try {
+      // Windows: npm installs sverklo as a `.cmd` shim. Spawning a .cmd
+      // file directly with stdio piping throws "spawn EINVAL" since
+      // Node CVE-2024-27980 tightened argument escaping (Aug 2024).
+      // The fix is to launch via the platform shell. On POSIX the
+      // resolved path is the JS file with a #! shebang — no shell
+      // wrapper needed. Issue #47.
+      const isWinShim =
+        process.platform === "win32" && /\.(cmd|bat)$/i.test(sverkloBin);
       const result = spawnSync(sverkloBin, ["."], {
         input,
         encoding: "utf-8",
         cwd: projectPath,
         timeout: 15000,
         maxBuffer: 4 * 1024 * 1024,
+        shell: isWinShim,
         // Forward .mcp.json's env block (incl. SVERKLO_PROFILE) so the
         // probe sees the same tool surface Claude Code would. process.env
         // alone is wrong: users rarely have SVERKLO_PROFILE in their shell.


### PR DESCRIPTION
Two day-2-after-v0.22.0 bugs Viraj filed. Doc-only fix for #48 ships separately in sverklo-site.

## Closes #47 — Windows: `sverklo doctor` MCP probe false-negative

\`sverklo doctor\` was reporting MCP handshake/tools/list/tools/call all failing on Windows even though Claude Code could connect to sverklo from the same project. Root cause: the doctor's MCP round-trip uses \`spawnSync\` with stdio piping; on Windows, the resolved \`sverklo\` path is the npm-installed \`.cmd\` shim, and spawning a .cmd file with stdio without a shell fails with \`spawn EINVAL\` since [Node CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2) tightened argument escaping (Aug 2024).

**Fix**: detect Windows .cmd/.bat shims and set \`shell: true\` for that one spawn. POSIX path (and any non-.cmd Windows path) is unchanged.

## Closes #49 — \`sverklo list\` shows stale "last indexed"

The registry's \`lastIndexed\` field is set when \`sverklo register\` runs but **the existing \`updateLastIndexed\` helper is never called outside tests** — so any subsequent reindex didn't update it. \`sverklo list\` showed registration time forever.

**Fix**: \`sverklo list\` now derives the timestamp from each repo's actual \`.sverklo/*.db\` mtime. Falls back to the registry stamp if the project path isn't accessible (renamed, deleted, network mount unreachable).

The honest signal is the index db mtime — that's what advances on every reindex. Keeping the registry update path for a future PR if/when we want symmetry.

## Test plan

- [x] Local: 631/632 tests passing (+0 new — bug fixes only, integration covered by existing suites)
- [x] Local smoke: \`sverklo list\` reads real db mtimes correctly on macOS
- [ ] CI: all 3 \`test\` + 3 \`install-smoke\` + 3 doctor-regression cells pass on Win/macOS/Linux
- [ ] CI Windows doctor-regression check (added in v0.22.1) MUST still pass — it asserts doctor doesn't surface the issue-#43 strings; the issue-#47 fix shouldn't change that

## Version

Bumped to **v0.22.2** — patch (two bug fixes, no API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)