### PR TITLE
fix: indexing UX + Ollama keep-alive + weights explain (#54, #55, #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [0.23.1] — 2026-05-21
+
+### Fixed
+
+- **#54** — `Indexing complete: N files, M chunks in Xms` now prints unconditionally on every flow that triggers indexing (`sverklo audit`, `sverklo index`, `sverklo reindex`). Previously gated on `SVERKLO_DEBUG=1` so default users never saw a total elapsed time. New `logSummary()` in `src/utils/logger.ts`.
+- **#55** — Ollama embedding requests now include `keep_alive: "10m"` + `connection: keep-alive` HTTP hints. Keeps the model resident between batches; closes a class of cold-load tax. Structural gap remains — ONNX is in-process, Ollama is over HTTP — so pick ONNX unless you specifically need Ollama's model selection. Documented at [sverklo.com/docs/config/](https://sverklo.com/docs/config/) with a comparison table.
+
+### Added
+
+- **#56 (partial)** — `sverklo weights explain <path>` subcommand. Walks `.sverklo.yaml` weight rules and shows which globs matched, in declaration order, with the winner marked. Closes the "no tooling to explain effective weights" gap. Remaining `#56` requests (git-worktree inherit, stale-project cleanup) deferred to a separate feature spec — both are filesystem-heavy and warrant their own spec-kit cycle.
+
+---
+
 ## [0.23.0] — 2026-05-20
 
 ### Added

--- a/bin/sverklo.ts
+++ b/bin/sverklo.ts
@@ -77,6 +77,7 @@ if (command && command !== "--help" && command !== "-h") {
       receipt: "Token-spend receipt for your recent Claude Code sessions. Shows where tokens went and projected yearly cost. Flags: --since 7d, --format plain|json.",
       memory: "Manage the memory store. Subcommands: show, edit, export.",
       grammars: "Manage tree-sitter grammars for the SVERKLO_PARSER=tree-sitter opt-in path. Subcommands: install.",
+      weights: "Inspect .sverklo.yaml weight rules. Subcommands: explain <path> — show which glob matched and the effective weight.",
       "audit-prompt": "Print a ready-to-paste codebase-audit prompt (hybrid agent workflow).",
       "review-prompt": "Print a ready-to-paste PR/MR-review prompt (hybrid agent workflow).",
       bench: "Run reproducible benchmarks on gin/nestjs/react.",
@@ -2076,6 +2077,55 @@ if (command === "grammars") {
     console.log(`\nNext: SVERKLO_PARSER=tree-sitter sverklo audit . to use them.\n`);
   }
   process.exit(errors.length > 0 ? 1 : 0);
+}
+
+if (command === "weights") {
+  // Inspect .sverklo.yaml weight rules. Closes part of issue #56.
+  //   sverklo weights explain <path> [project-path]
+  const sub = args[1];
+  if (sub !== "explain") {
+    console.error(
+      "Usage: sverklo weights explain <path> [project-path]\n" +
+        "  <path> is a repo-relative file path to test against the weight rules.",
+    );
+    process.exit(2);
+  }
+  const targetPath = args[2];
+  if (!targetPath) {
+    console.error("sverklo weights explain: missing <path> argument.");
+    process.exit(2);
+  }
+  const projectPath = await resolveProjectPath(args.slice(3));
+  const { loadSverkloConfig, explainWeight } = await import("../src/utils/config-file.js");
+  const { join: joinPath } = await import("node:path");
+  const { existsSync: fsExists } = await import("node:fs");
+
+  const configCandidates = [
+    joinPath(projectPath, ".sverklo.yaml"),
+    joinPath(projectPath, ".sverklo.yml"),
+  ];
+  const configPath = configCandidates.find((p) => fsExists(p)) ?? null;
+  const config = loadSverkloConfig(projectPath);
+  const explanation = explainWeight(config, targetPath, configPath);
+
+  console.log("");
+  console.log(`Weight resolution for: ${targetPath}`);
+  console.log(`Project: ${projectPath}`);
+  console.log(`Config:  ${explanation.source ?? "(no .sverklo.yaml found — defaults apply)"}`);
+  console.log("");
+  if (explanation.matches.length === 0) {
+    console.log(`  No glob matched. Effective weight: ${explanation.effective.toFixed(2)} (default)`);
+  } else {
+    console.log(`  Matched globs (in declaration order):`);
+    explanation.matches.forEach((m, i) => {
+      const arrow = i === explanation.matches.length - 1 ? "← winner" : "  (overridden)";
+      console.log(`    [${m.index + 1}] ${m.glob}  weight=${m.weight.toFixed(2)}  ${arrow}`);
+    });
+    console.log("");
+    console.log(`  Effective weight: ${explanation.effective.toFixed(2)} (last matching glob wins)`);
+  }
+  console.log("");
+  process.exit(0);
 }
 
 if (command === "memory") {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sverklo",
   "mcpName": "io.github.sverklo/sverklo",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Local-first code intelligence — MCP server for Claude Code, Cursor, Windsurf, Zed. Symbol graph, blast-radius, git-pinned memory. 43× fewer tokens than naive grep on the public bench. MIT, zero-config.",
   "type": "module",
   "bin": {

--- a/src/indexer/embedding-providers.ts
+++ b/src/indexer/embedding-providers.ts
@@ -222,8 +222,16 @@ class OllamaProvider implements EmbeddingProvider {
       try {
         const probeRes = await fetch(`${this.baseUrl}/api/embed`, {
           method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ model: this.model, input: ["dimension probe"] }),
+          headers: {
+            "content-type": "application/json",
+            "connection": "keep-alive",
+          },
+          keepalive: true,
+          body: JSON.stringify({
+            model: this.model,
+            input: ["dimension probe"],
+            keep_alive: "10m",
+          }),
         });
         if (probeRes.ok) {
           const probeJson = (await probeRes.json()) as OllamaEmbedResponse;
@@ -250,10 +258,22 @@ class OllamaProvider implements EmbeddingProvider {
 
     for (let i = 0; i < texts.length; i += BATCH) {
       const batch = texts.slice(i, i + BATCH);
+      // `keep_alive` keeps the model resident on the Ollama server
+      // between batches — otherwise the model can be unloaded after
+      // idle gaps and the next batch pays the cold-load tax again.
+      // Closes part of issue #55.
       const res = await fetch(`${this.baseUrl}/api/embed`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ model: this.model, input: batch }),
+        headers: {
+          "content-type": "application/json",
+          "connection": "keep-alive",
+        },
+        keepalive: true,
+        body: JSON.stringify({
+          model: this.model,
+          input: batch,
+          keep_alive: "10m",
+        }),
       });
       if (!res.ok) {
         const body = await res.text().catch(() => "<no body>");

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -34,7 +34,7 @@ import { buildDocLinks } from "./doc-linker.js";
 import { extractReferences } from "./symbol-extractor.js";
 import { createIgnoreFilter } from "../utils/ignore.js";
 import { estimateTokens } from "../utils/tokens.js";
-import { log, logError, logTiming } from "../utils/logger.js";
+import { log, logError, logSummary, logTiming } from "../utils/logger.js";
 import { loadSverkloConfig, type SverkloConfig } from "../utils/config-file.js";
 import { track } from "../telemetry/index.js";
 import type { ProjectConfig, ImportRef, IndexStatus } from "../types/index.js";
@@ -509,7 +509,10 @@ export class Indexer implements IndexFiles, IndexCode, IndexGraph, IndexMemory, 
       // for up to FRESHNESS_CACHE_MS after a forced rebuild.
       this.freshnessCache = null;
       const elapsed = this.lastIndexedTime - startTime;
-      log(
+      // Always-on summary so users see total time on every indexing
+      // flow (audit, index, reindex) without needing SVERKLO_DEBUG=1.
+      // Issue #54.
+      logSummary(
         `Indexing complete: ${this.fileStore.count()} files, ` +
           `${this.chunkStore.count()} chunks in ${elapsed}ms`
       );

--- a/src/utils/config-file.test.ts
+++ b/src/utils/config-file.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadSverkloConfig, getWeight } from "./config-file.js";
+import { loadSverkloConfig, getWeight, explainWeight } from "./config-file.js";
 
 describe("loadSverkloConfig", () => {
   let tmpRoot: string;
@@ -201,5 +201,49 @@ describe("getWeight", () => {
       ],
     };
     expect(getWeight(config, "src/foo.ts")).toBe(2.0);
+  });
+});
+
+describe("explainWeight — issue #56", () => {
+  it("returns defaults when no config", () => {
+    const r = explainWeight(null, "src/foo.ts");
+    expect(r.effective).toBe(1.0);
+    expect(r.matches).toEqual([]);
+    expect(r.source).toBeNull();
+  });
+
+  it("returns defaults when no glob matches", () => {
+    const config = { weights: [{ glob: "tests/**", weight: 0.5 }] };
+    const r = explainWeight(config, "src/foo.ts");
+    expect(r.effective).toBe(1.0);
+    expect(r.matches).toEqual([]);
+  });
+
+  it("captures the single matching glob", () => {
+    const config = { weights: [{ glob: "src/**", weight: 2.5 }] };
+    const r = explainWeight(config, "src/foo.ts");
+    expect(r.effective).toBe(2.5);
+    expect(r.matches).toEqual([{ glob: "src/**", weight: 2.5, index: 0 }]);
+  });
+
+  it("captures every match in declaration order; last wins", () => {
+    const config = {
+      weights: [
+        { glob: "tests/**", weight: 0.8 },
+        { glob: "tests/fixtures/**", weight: 0.5 },
+      ],
+    };
+    const r = explainWeight(config, "tests/fixtures/sample.json");
+    expect(r.effective).toBe(0.5);
+    expect(r.matches).toEqual([
+      { glob: "tests/**", weight: 0.8, index: 0 },
+      { glob: "tests/fixtures/**", weight: 0.5, index: 1 },
+    ]);
+  });
+
+  it("passes through the source path", () => {
+    const config = { weights: [{ glob: "src/**", weight: 1.5 }] };
+    const r = explainWeight(config, "src/x.ts", "/repo/.sverklo.yaml");
+    expect(r.source).toBe("/repo/.sverklo.yaml");
   });
 });

--- a/src/utils/config-file.ts
+++ b/src/utils/config-file.ts
@@ -145,3 +145,38 @@ export function getWeight(
 
   return weight;
 }
+
+/**
+ * Like `getWeight`, but returns the full match trail so callers can
+ * explain to the user which glob actually won. Used by
+ * `sverklo weights explain <file>` (issue #56).
+ *
+ * Returns:
+ *   - effective: the final weight that getWeight() would return
+ *   - matches:   every glob entry that matched, in declaration order.
+ *                The LAST entry in this list is the one that took effect.
+ *   - source:    where the config was loaded from, or null if no config.
+ */
+export function explainWeight(
+  config: SverkloConfig | null,
+  relativePath: string,
+  source: string | null = null,
+): {
+  effective: number;
+  matches: Array<{ glob: string; weight: number; index: number }>;
+  source: string | null;
+} {
+  const matches: Array<{ glob: string; weight: number; index: number }> = [];
+  if (!config?.weights || config.weights.length === 0) {
+    return { effective: 1.0, matches, source };
+  }
+  config.weights.forEach((entry, index) => {
+    if (picomatch.isMatch(relativePath, entry.glob)) {
+      matches.push({ glob: entry.glob, weight: entry.weight, index });
+    }
+  });
+  const effective = matches.length === 0
+    ? 1.0
+    : matches[matches.length - 1]!.weight;
+  return { effective, matches, source };
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,6 +21,16 @@ export function logTiming(msg: string): void {
   }
 }
 
+/**
+ * Always-on summary line. Used by the indexer for the final "Indexing
+ * complete" output so users see total elapsed time on every flow that
+ * triggers indexing (`sverklo audit`, `sverklo index`, etc.), without
+ * needing to opt into SVERKLO_DEBUG. Issue #54.
+ */
+export function logSummary(msg: string): void {
+  process.stderr.write(`${msg}\n`);
+}
+
 export function logError(msg: string, err?: unknown): void {
   process.stderr.write(`[sverklo:error] ${msg}\n`);
   if (err instanceof Error) {


### PR DESCRIPTION
Three issues addressed in one v0.23.1 patch — all user-visible UX improvements driven by Viraj's reports this week.

## Closes #54 — Indexing UX timing consistency

\`Indexing complete: N files, M chunks in Xms\` was gated on \`SVERKLO_DEBUG=1\` via the \`log()\` helper, so default users never saw total elapsed time on \`sverklo audit\` / \`sverklo index\` / \`sverklo reindex\`. New \`logSummary()\` in \`src/utils/logger.ts\` writes unconditionally to stderr. \`Indexer.index()\` now uses it for the summary line. \`--timing\` flag's per-phase breakdown is unchanged.

## Closes #55 — Ollama performance (partial)

Embedding requests now include \`keep_alive: \"10m\"\` on the JSON body, \`connection: keep-alive\` header, and \`keepalive: true\` on the fetch options. This keeps the model resident between batches — closes the cold-load tax that hit between sverklo's 128-input batches when the model unloaded in the gap.

Structural gap remains: ONNX is in-process, Ollama is over HTTP, so ONNX will always be materially faster. Documented at [sverklo.com/docs/config](https://sverklo.com/docs/config/) with a comparison table and clear guidance: pick ONNX unless you specifically need Ollama's model selection. Recommendation in the issue thread will be: stay on ONNX (the default) for indexing.

## Closes #56 — Partial — weight-config explainability

New \`sverklo weights explain <path>\` subcommand. Calls a new \`explainWeight()\` helper in \`config-file.ts\` that returns every matching glob in declaration order with the winner marked.

Example:

\`\`\`
$ sverklo weights explain tests/fixtures/sample.json

Weight resolution for: tests/fixtures/sample.json
Project: /repo
Config:  /repo/.sverklo.yaml

  Matched globs (in declaration order):
    [1] tests/**           weight=0.80    (overridden)
    [2] tests/fixtures/**  weight=0.50  ← winner

  Effective weight: 0.50 (last matching glob wins)
\`\`\`

5 new unit tests in \`config-file.test.ts\` covering: no-config, no-match, single-match, multi-match (last-wins), and source-path passthrough.

**Deferred from #56**: \`sverklo init --inherit\` (worktree index reuse) and stale-worktree cleanup. Both are filesystem-heavy and warrant their own spec-kit cycle. Tracked in the issue thread.

## Test plan

- [x] \`npm test\` — 647/648 passing locally (+5 new)
- [x] \`sverklo weights explain\` smoke verified end-to-end on a fixture \`.sverklo.yaml\`
- [ ] CI: 3 test cells + 3 install-smoke + doctor-regression + audit + latency, all on Windows/macOS/Linux × Node 24

## Version

Bumped to **v0.23.1** — patch (three bug fixes/UX improvements, no breaking changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)