### PR TITLE
feat(server): cross-repo MCP search + dashboard error banner (v0.24.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ When sverklo MCP server is connected, **always prefer sverklo tools over built-i
 - Use `sverklo_remember` to save important decisions
 - Use `sverklo_recall` to check past decisions
 
+**Cross-project search** (v0.24.0+): if you need to read code in a neighboring sverklo-registered project (not the current cwd), call `sverklo_list_repos` and then pass `repo:"<name>"` to `sverklo_search` / `sverklo_lookup` / `sverklo_investigate` / `sverklo_search_iterative`. Don't fall back to grep when the data is already indexed.
+
 This is our own product — dogfood it.
 
 ## Project structure

--- a/src/server/assets/dashboard.css
+++ b/src/server/assets/dashboard.css
@@ -668,6 +668,18 @@ footer.status .spacer { flex: 1; }
 .cmdk-item.selected { background: var(--bg-3); color: var(--accent); }
 .cmdk-item .kind { font-size: 11px; color: var(--text-3); }
 
+/* error banner — surfaces init() failures instead of silent blank page */
+.error-banner {
+  background: #4a1f1f;
+  color: #f5c2c2;
+  padding: 10px 20px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  border-bottom: 1px solid #6b2a2a;
+}
+.error-banner[hidden] { display: none; }
+.error-banner code { background: rgba(0,0,0,0.25); padding: 1px 5px; border-radius: 3px; }
+
 /* scrollbars */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/src/server/assets/dashboard.js
+++ b/src/server/assets/dashboard.js
@@ -11,7 +11,14 @@ let state = {
 // ────────── API ──────────
 async function api(path) {
   const r = await fetch(path);
-  return r.json();
+  if (!r.ok) {
+    throw new Error('GET ' + path + ' → HTTP ' + r.status + ' ' + r.statusText);
+  }
+  try {
+    return await r.json();
+  } catch (e) {
+    throw new Error('GET ' + path + ' → invalid JSON: ' + (e && e.message ? e.message : e));
+  }
 }
 
 // ────────── INIT ──────────
@@ -20,7 +27,7 @@ async function init() {
   state.stats = await api('/api/stats');
 
   document.getElementById('bc-project').textContent = state.status.projectName;
-  document.getElementById('bc-branch').textContent = 'main'; // TODO: actual branch
+  document.getElementById('bc-branch').textContent = state.status.branch || 'detached';
   document.getElementById('bc-indexed').textContent = state.status.lastIndexedAt
     ? 'indexed ' + formatAge(state.status.lastIndexedAt)
     : 'not indexed';
@@ -651,4 +658,17 @@ function formatBytes(b) {
   return (b/1048576).toFixed(1) + ' MB';
 }
 
-init();
+function showInitError(err) {
+  const banner = document.getElementById('error-banner');
+  if (!banner) return;
+  const msg = (err && err.message) ? err.message : String(err);
+  banner.innerHTML =
+    '<strong>Dashboard failed to load.</strong> ' +
+    'Check the sverklo process for errors, then refresh. Last error: <code>' +
+    msg.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c]) +
+    '</code>';
+  banner.removeAttribute('hidden');
+  console.error('[sverklo dashboard] init failed', err);
+}
+
+init().catch(showInitError);

--- a/src/server/dashboard-html.ts
+++ b/src/server/dashboard-html.ts
@@ -47,6 +47,8 @@ export function getDashboardHTML(): string {
 </head>
 <body>
 
+<div id="error-banner" class="error-banner" hidden></div>
+
 <div class="app">
   <!-- ────────── HEADER ────────── -->
   <header class="chrome">

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -6,6 +6,7 @@ import type { Indexer } from "../indexer/indexer.js";
 import { log } from "../utils/logger.js";
 import { getDashboardHTML } from "./dashboard-html.js";
 import { getClustersJSON } from "./tools/clusters.js";
+import { getGitState } from "../memory/git-state.js";
 
 // Read the package version once at module load so the dashboard footer
 // and any other surface can show what version is actually running.
@@ -51,9 +52,16 @@ export function startHttpServer(indexer: Indexer, port: number = 3847): void {
       // ─── API routes ───
       if (url.pathname === "/api/status") {
         const status = indexer.getStatus();
-        // Include the running package version so the dashboard footer
-        // can show what's actually running instead of a hardcoded string.
-        json(res, { ...status, version: PACKAGE_VERSION });
+        const gitState = getGitState(indexer.rootPath);
+        // Include the running package version + git branch so the dashboard
+        // breadcrumb shows what's actually running instead of a hardcoded
+        // string. branch is null when the repo has no git, no commits, or
+        // when execSync fails (detached HEAD).
+        json(res, {
+          ...status,
+          version: PACKAGE_VERSION,
+          branch: gitState.branch,
+        });
       } else if (url.pathname === "/api/stats") {
         // Aggregated stats for the dashboard overview
         const files = indexer.fileStore.getAll();

--- a/src/server/tools/investigate.ts
+++ b/src/server/tools/investigate.ts
@@ -19,6 +19,13 @@ export const investigateTool = {
         type: "string",
         description: "Natural-language question or exploration target.",
       },
+      repo: {
+        type: "string",
+        description:
+          "Optional: name of a registered repo to investigate (see sverklo_list_repos). " +
+          "Defaults to the current workspace. Use this to investigate a sibling project " +
+          "that has been sverklo-init'd but isn't the current cwd.",
+      },
       scope: {
         type: "string",
         description: "Optional path prefix to limit all retrievers to, e.g. 'src/api/'.",

--- a/src/server/tools/lookup.ts
+++ b/src/server/tools/lookup.ts
@@ -20,6 +20,13 @@ export const lookupTool = {
         type: "string",
         description: "Symbol name to look up (exact or prefix match)",
       },
+      repo: {
+        type: "string",
+        description:
+          "Optional: name of a registered repo to search (see sverklo_list_repos). " +
+          "Defaults to the current workspace. Use this to look up a symbol in a sibling " +
+          "project that has been sverklo-init'd but isn't the current cwd.",
+      },
       type: {
         type: "string",
         enum: [

--- a/src/server/tools/search-iterative.ts
+++ b/src/server/tools/search-iterative.ts
@@ -30,6 +30,13 @@ export const searchIterativeTool = {
         type: "number",
         description: "Candidate pool size (default 200). Capped at 500.",
       },
+      repo: {
+        type: "string",
+        description:
+          "Optional: name of a registered repo to search (see sverklo_list_repos). " +
+          "Defaults to the current workspace. Use this to widen the iterative search " +
+          "over a sibling project that has been sverklo-init'd but isn't the current cwd.",
+      },
     },
     required: ["query"],
   },

--- a/src/server/tools/search.ts
+++ b/src/server/tools/search.ts
@@ -27,6 +27,13 @@ export const searchTool = {
         type: "string",
         description: "Natural language query or code pattern",
       },
+      repo: {
+        type: "string",
+        description:
+          "Optional: name of a registered repo to search (see sverklo_list_repos). " +
+          "Defaults to the current workspace. Use this to query a sibling project that " +
+          "has been sverklo-init'd but isn't the current cwd — avoids falling back to grep.",
+      },
       token_budget: {
         type: "number",
         description: "Max tokens to return (default: 4000)",


### PR DESCRIPTION
## Summary

Two P0 fixes shipping together as v0.24.0, surfaced by a real user in the wild (2026-05-22) ~14h before the public growth campaign launches:

1. **Cross-project tool-coverage gap.** Four search-family MCP tool schemas didn't expose the `repo` field even though the dispatcher (mcp-server.ts:860) and `IndexerPool.getIndexer(repoName)` (indexer-pool.ts) already supported it. Result: Claude Code fell back to grep when asked about a neighboring sverklo-init'd project. Fix: add optional `repo: string` to `sverklo_search`, `sverklo_lookup`, `sverklo_investigate`, `sverklo_search_iterative`. Zero handler changes — dispatcher does the work. `IndexerPool.getIndexer()` already throws an actionable "available repos: …" error for unknown names.

2. **Dashboard silent-failure.** `dashboard.js:654` called `init()` without error handling. If `/api/status` or `/api/stats` 500s, the whole dashboard rendered as a blank page. Fix: visible error banner with check-process hint; hardened `api()` to throw on non-2xx + invalid JSON. While there, replaced the hardcoded `'main'` branch breadcrumb (dashboard.js:23) with the actual git branch via `getGitState(indexer.rootPath)`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` (src/server, src/search, src/memory/git-state, src/utils/config) — 244 passed, 1 skipped, 0 failed
- [ ] CI matrix green (Ubuntu + Windows + macOS, Node 24)
- [ ] Smoke: `sverklo ui .` on a fresh checkout — verify banner stays hidden, branch shows correctly
- [ ] Smoke: with two repos registered, `sverklo_search` MCP call with `repo:"other-project"` returns results from the other repo

## Constitution check

- **I — Local-first**: ✅ No network. Cross-repo reads sibling `.sverklo/` files locally.
- **II — Dogfood**: ✅ Sverklo itself uses the cross-repo capability now (per CLAUDE.md).
- **III — Public benchmarks**: ⏳ "Cross-repo search added 0 ms overhead" claim deferred to follow-up benchmark; no public claim in this PR depends on numbers.
- **IV — Test-first CI**: ✅ Existing tests still green. Schema changes are additive; no new behavior to test beyond what dispatcher already covers.
- **V — Ship small**: ✅ Two narrow bug fixes, one PR.

## Why v0.24.0 (minor) not v0.23.2 (patch)

The `repo` field is **new MCP surface area** — clients that introspect tool schemas (the `tools/list` probe) will see a new optional field. SemVer says that's a minor bump even though existing callers continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)