### PR TITLE
chore(ci): node --check shipped browser .js assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      # 2026-05-22: the Tier-2.3 dashboard split shipped a SyntaxError
+      # in dashboard.js that hid for 8 days because TS build + vitest
+      # never load the browser assets. Pipe every shipped .js asset
+      # through `node --check` so a parse error fails CI immediately.
+      - run: npm run lint:assets
       - run: npm test
 
   install-smoke:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/",
+    "lint:assets": "node scripts/lint-assets.mjs",
     "verify:plugin-sync": "node scripts/verify-plugin-sync.mjs",
     "prepublishOnly": "node scripts/verify-plugin-sync.mjs && rm -rf dist && npm run build",
     "benchmark": "node --experimental-strip-types benchmark/benchmark.ts",

--- a/scripts/lint-assets.mjs
+++ b/scripts/lint-assets.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Static-syntax check for browser assets shipped under src/server/assets/.
+//
+// Background — 2026-05-22: the Tier-2.3 commit (43e8174, 2026-05-14)
+// extracted dashboard.js out of a template literal in dashboard-html.ts
+// without unwinding the doubled single-quote escapes. Result: the file
+// had a literal SyntaxError on every parse, the entire dashboard rendered
+// blank for 8 days, and no one noticed because (a) TypeScript build
+// passes (the file is .js, not .ts), (b) the 652 vitest tests don't
+// load it in a browser, (c) no one ran `sverklo ui .` in CI.
+//
+// This script gates that exact regression by piping every shipped .js
+// asset through node's parser. `node --check` exits non-zero on
+// SyntaxError. Cheap (<1s) and runs in the existing test job.
+//
+// Not in scope: ESLint-style lint, runtime correctness, CSS validation.
+// Those would need an actual browser or jsdom; this is a pre-flight.
+
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ASSETS_DIR = "src/server/assets";
+
+const jsFiles = readdirSync(ASSETS_DIR)
+  .filter((name) => name.endsWith(".js"))
+  // d3 is a vendored library — ESM parse errors are upstream's problem,
+  // and it's already minified so `node --check` would complain about
+  // strict-mode-only syntax that runs fine in browsers.
+  .filter((name) => name !== "d3.min.js");
+
+if (jsFiles.length === 0) {
+  console.log("[lint-assets] no .js files to check");
+  process.exit(0);
+}
+
+let failed = 0;
+for (const name of jsFiles) {
+  const path = join(ASSETS_DIR, name);
+  const result = spawnSync(process.execPath, ["--check", path], {
+    encoding: "utf-8",
+  });
+  if (result.status === 0) {
+    console.log(`[lint-assets] ✓ ${relative(process.cwd(), path)}`);
+  } else {
+    console.error(`[lint-assets] ✗ ${relative(process.cwd(), path)}`);
+    if (result.stderr) process.stderr.write(result.stderr);
+    failed++;
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n[lint-assets] ${failed} file(s) failed syntax check.`);
+  process.exit(1);
+}
+
+console.log(`\n[lint-assets] all ${jsFiles.length} file(s) parsed cleanly.`);


### PR DESCRIPTION
## Summary

Adds `npm run lint:assets` (a `node --check` over every shipped browser .js under `src/server/assets/`) to the existing CI test job.

## Why

The Tier-2.3 split (commit `43e8174`, 2026-05-14) shipped a literal `SyntaxError` in `dashboard.js` that hid for 8 days. The bug only surfaced when a real user opened the dashboard at v0.24.0 and reported `Uncaught SyntaxError: Unexpected string (at dashboard.js:348:59)`. v0.25.1 fixed the regression; this PR makes sure that exact failure mode can't recur silently again.

Root cause for the 8-day blindness:
- TypeScript build doesn't parse `.js` files (they're not TS)
- vitest never loads browser assets
- no CI step actually loaded the dashboard

## Scope

- `scripts/lint-assets.mjs` — new ~50-line script. Spawns `node --check` on each `.js` file in `src/server/assets/` (excludes `d3.min.js`, the vendored minified library).
- `package.json` — new `lint:assets` npm script.
- `.github/workflows/ci.yml` — one new `- run: npm run lint:assets` step in the `test` job, between `npm run build` and `npm test`.

## Test plan

- [x] `npm run lint:assets` passes locally on the v0.25.1 codebase
- [ ] This PR's own CI run validates the workflow change end-to-end (would fail if I broke the YAML)
- [ ] Verify by branching, intentionally re-introducing the dashboard.js SyntaxError, and confirming CI fails on the new step (deferred — current PR is verification enough for green path)

## Out of scope

Browser-runtime correctness, ESLint of the assets, CSS validation. Those would need a real browser or jsdom. This is parse-time only — the minimal gate that catches the failure mode we actually saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)