### PR TITLE
feat(benchmark): replace mock bifrost baseline with real HTTP gateway…

### DIFF
--- a/benchmark/src/baselines/gateway/bifrost.test.ts
+++ b/benchmark/src/baselines/gateway/bifrost.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { BifrostBaseline } from "./bifrost.ts";
+import type { Task } from "../../types.ts";
+
+// Smoke tests for the Bifrost baseline (PR #67).
+//
+// The gateway-unreachable path is the load-bearing case: this baseline
+// is opt-in via BASELINES=bifrost, but when it does run we don't want
+// 100 tasks × 30s timeouts wasted on a misconfigured gateway. Probe
+// once in setup, then short-circuit each task if the gateway didn't
+// answer. The other side (real /v1/chat/completions integration) is
+// covered by manual + integration runs against a live Bifrost.
+
+describe("BifrostBaseline", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("skip-mode: when the gateway is unreachable at setup, run() returns empty predictions without calling /v1/chat/completions", async () => {
+    // /v1/models fetch fails (network error or non-200). setupForDataset
+    // catches and sets cachedModel = null. Then run() must NOT issue any
+    // additional fetch calls — it should short-circuit immediately.
+    let chatCompletionsCalled = false;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("/v1/chat/completions")) chatCompletionsCalled = true;
+      throw new Error("simulated network failure");
+    }) as unknown as typeof fetch;
+
+    const baseline = new BifrostBaseline();
+    await baseline.setupForDataset({ name: "test", rootPath: "/tmp" });
+
+    const task: Task = {
+      id: "t1",
+      category: "P1",
+      query: "find authentication",
+      datasetName: "test",
+    } as Task;
+
+    const out = await baseline.run(task);
+
+    expect(chatCompletionsCalled).toBe(false);
+    expect(out.prediction.kind).toBe("locations");
+    expect(out.rawPayload).toContain("unreachable");
+    // Skip-mode returns 0 wall time — important so the bench doesn't
+    // attribute a 30s timeout to "Bifrost is slow."
+    expect(out.wallTimeMs).toBe(0);
+  });
+
+  it("uses SVERKLO_BIFROST_BASE_URL env var when set", async () => {
+    // Inspect the URL that /v1/models is fetched from. The baseline
+    // should respect the env var instead of hardcoded 127.0.0.1:8080.
+    const seenUrls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const u = typeof url === "string" ? url : url.toString();
+      seenUrls.push(u);
+      throw new Error("ok — we just want the URL");
+    }) as unknown as typeof fetch;
+
+    const prev = process.env.SVERKLO_BIFROST_BASE_URL;
+    process.env.SVERKLO_BIFROST_BASE_URL = "http://gateway.internal:9000";
+    try {
+      const baseline = new BifrostBaseline();
+      await baseline.setupForDataset({ name: "test", rootPath: "/tmp" });
+    } finally {
+      if (prev === undefined) delete process.env.SVERKLO_BIFROST_BASE_URL;
+      else process.env.SVERKLO_BIFROST_BASE_URL = prev;
+    }
+
+    expect(seenUrls.some((u) => u.startsWith("http://gateway.internal:9000"))).toBe(true);
+  });
+
+  it("returns the correct empty-prediction shape per task category", async () => {
+    // Mock so the gateway 'fails' — we just need run() to take the
+    // skip path so we can inspect the empty-prediction shapes.
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("forced");
+    }) as unknown as typeof fetch;
+
+    const baseline = new BifrostBaseline();
+    await baseline.setupForDataset({ name: "test", rootPath: "/tmp" });
+
+    const p1 = await baseline.run({ id: "t", category: "P1", query: "q", datasetName: "d" } as Task);
+    expect(p1.prediction.kind).toBe("locations");
+
+    const p4 = await baseline.run({ id: "t", category: "P4", query: "q", datasetName: "d" } as Task);
+    expect(p4.prediction.kind).toBe("deps");
+
+    const p5 = await baseline.run({ id: "t", category: "P5", query: "q", datasetName: "d" } as Task);
+    expect(p5.prediction.kind).toBe("names");
+  });
+});

--- a/benchmark/src/baselines/gateway/bifrost.ts
+++ b/benchmark/src/baselines/gateway/bifrost.ts
@@ -4,7 +4,9 @@ import type { Task, ExpectedAnswer, Location } from "../../types.ts";
 export class BifrostBaseline implements Baseline {
   name = "bifrost";
 
-  private baseUrl = "http://127.0.0.1:8080";
+  // Configurable so users (and CI) can point at a non-loopback gateway.
+  // Default keeps the original loopback target.
+  private baseUrl = process.env.SVERKLO_BIFROST_BASE_URL || "http://127.0.0.1:8080";
 
   private cachedModel: string | null = null;
   private firstTaskInDataset = true;
@@ -14,8 +16,14 @@ export class BifrostBaseline implements Baseline {
     this.firstTaskInDataset = true;
     this.indexCostMs = 0;
 
-    // 🔥 preload model once for fairness
-    this.cachedModel = await this.getFirstAvailableModel();
+    // Probe once. If the gateway is unreachable here, leave cachedModel
+    // null and run() will short-circuit each task — much better than
+    // burning a 30s timeout per task on a 100-task dataset.
+    try {
+      this.cachedModel = await this.getFirstAvailableModel();
+    } catch {
+      this.cachedModel = null;
+    }
   }
 
   async teardownForDataset() {}
@@ -23,10 +31,21 @@ export class BifrostBaseline implements Baseline {
   async run(task: Task): Promise<BaselineOutput> {
     const start = Date.now();
 
-    try {
-      const model = this.cachedModel ?? await this.getFirstAvailableModel();
+    // Gateway unreachable at setup — return empty predictions immediately.
+    // Bench numbers will reflect "no Bifrost run" rather than 30s timeouts.
+    if (!this.cachedModel) {
+      return {
+        prediction: this.emptyPrediction(task.category),
+        rawPayload: "bifrost gateway unreachable at setup",
+        toolCalls: 0,
+        wallTimeMs: 0,
+        coldStartMs: 0,
+        warmCallMs: 0,
+      };
+    }
 
-      const res = await this.callLLM(this.buildPrompt(task), model);
+    try {
+      const res = await this.callLLM(this.buildPrompt(task), this.cachedModel);
       const prediction = this.parsePrediction(task.category, res);
 
       return {
@@ -52,27 +71,27 @@ export class BifrostBaseline implements Baseline {
   }
 
   // -----------------------------
-  // MODEL DISCOVERY (CRITICAL FIX)
+  // MODEL DISCOVERY
   // -----------------------------
+  // Throws on network failure / empty model list. Caller decides whether
+  // that's fatal (e.g., setupForDataset catches and switches to skip mode).
   private async getFirstAvailableModel(): Promise<string> {
-    try {
-      const res = await fetch(`${this.baseUrl}/v1/models`);
-      const json = await res.json();
-
-      const models =
-        json?.data?.map((m: any) => m.id) ??
-        json?.models ??
-        [];
-
-      if (!models.length) {
-        throw new Error("No models available in Bifrost");
-      }
-
-      return models[0];
-    } catch (e) {
-      // fallback (safe default)
-      return "phi3:mini";
+    const res = await fetch(`${this.baseUrl}/v1/models`);
+    if (!res.ok) {
+      throw new Error(`Bifrost /v1/models returned ${res.status} ${res.statusText}`);
     }
+    const json = await res.json();
+
+    const models =
+      json?.data?.map((m: any) => m.id) ??
+      json?.models ??
+      [];
+
+    if (!models.length) {
+      throw new Error("No models available in Bifrost");
+    }
+
+    return models[0];
   }
 
   // -----------------------------

--- a/benchmark/src/baselines/gateway/bifrost.ts
+++ b/benchmark/src/baselines/gateway/bifrost.ts
@@ -1,0 +1,204 @@
+import type { Baseline, BaselineOutput } from "../base.ts";
+import type { Task, ExpectedAnswer, Location } from "../../types.ts";
+
+export class BifrostBaseline implements Baseline {
+  name = "bifrost";
+
+  private baseUrl = "http://127.0.0.1:8080";
+
+  private cachedModel: string | null = null;
+  private firstTaskInDataset = true;
+  private indexCostMs = 0;
+
+  async setupForDataset(_: { name: string; rootPath: string }) {
+    this.firstTaskInDataset = true;
+    this.indexCostMs = 0;
+
+    // 🔥 preload model once for fairness
+    this.cachedModel = await this.getFirstAvailableModel();
+  }
+
+  async teardownForDataset() {}
+
+  async run(task: Task): Promise<BaselineOutput> {
+    const start = Date.now();
+
+    try {
+      const model = this.cachedModel ?? await this.getFirstAvailableModel();
+
+      const res = await this.callLLM(this.buildPrompt(task), model);
+      const prediction = this.parsePrediction(task.category, res);
+
+      return {
+        prediction,
+        rawPayload: JSON.stringify(res),
+        toolCalls: 0,
+        wallTimeMs: Date.now() - start,
+        coldStartMs: this.firstTaskInDataset ? this.indexCostMs : 0,
+        warmCallMs: Date.now() - start,
+      };
+    } catch (err) {
+      return {
+        prediction: this.emptyPrediction(task.category),
+        rawPayload: String(err),
+        toolCalls: 0,
+        wallTimeMs: Date.now() - start,
+        coldStartMs: 0,
+        warmCallMs: 0,
+      };
+    } finally {
+      this.firstTaskInDataset = false;
+    }
+  }
+
+  // -----------------------------
+  // MODEL DISCOVERY (CRITICAL FIX)
+  // -----------------------------
+  private async getFirstAvailableModel(): Promise<string> {
+    try {
+      const res = await fetch(`${this.baseUrl}/v1/models`);
+      const json = await res.json();
+
+      const models =
+        json?.data?.map((m: any) => m.id) ??
+        json?.models ??
+        [];
+
+      if (!models.length) {
+        throw new Error("No models available in Bifrost");
+      }
+
+      return models[0];
+    } catch (e) {
+      // fallback (safe default)
+      return "phi3:mini";
+    }
+  }
+
+  // -----------------------------
+  // CALL BIFROST
+  // -----------------------------
+  private async callLLM(prompt: string, model: string) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30000);
+
+    try {
+      const res = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: prompt }],
+          temperature: 0,
+          stream: false,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+
+      return await res.json();
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  // -----------------------------
+  // PROMPT
+  // -----------------------------
+  private buildPrompt(task: Task): string {
+    return `
+You are a deterministic code analysis system.
+
+Return ONLY valid JSON.
+
+Task: ${task.category}
+Query: ${task.query}
+
+P1/P2:
+{"locations":[{"file":"x","line":1}]}
+
+P4:
+{"imports":[],"importers":[]}
+
+P5:
+{"names":[]}
+`.trim();
+  }
+
+  // -----------------------------
+  // PARSER
+  // -----------------------------
+  private parsePrediction(category: string, res: any): ExpectedAnswer {
+    const content = res?.choices?.[0]?.message?.content ?? "";
+    const data = this.safeJsonParse(content);
+
+    if (category === "P4") {
+      return {
+        kind: "deps",
+        imports: data.imports ?? [],
+        importers: data.importers ?? [],
+      };
+    }
+
+    if (category === "P5") {
+      return {
+        kind: "names",
+        names: data.names ?? [],
+      };
+    }
+
+    return {
+      kind: "locations",
+      locations: this.extractLocations(data),
+    };
+  }
+
+  private safeJsonParse(text: string): any {
+    if (!text) return {};
+
+    try {
+      return JSON.parse(text);
+    } catch {}
+
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return {};
+
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return {};
+    }
+  }
+
+  private extractLocations(data: any): Location[] {
+    const list = data.locations ?? [];
+    const out: Location[] = [];
+    const seen = new Set<string>();
+
+    for (const l of list) {
+      if (!l?.file || !l?.line) continue;
+
+      const key = `${l.file}:${l.line}`;
+      if (seen.has(key)) continue;
+
+      seen.add(key);
+      out.push({
+        file: l.file,
+        line: Number(l.line),
+      });
+    }
+
+    return out;
+  }
+
+  private emptyPrediction(category: string): ExpectedAnswer {
+    if (category === "P4") return { kind: "deps", imports: [], importers: [] };
+    if (category === "P5") return { kind: "names", names: [] };
+    return { kind: "locations", locations: [] };
+  }
+}

--- a/benchmark/src/runner/run-primitive.ts
+++ b/benchmark/src/runner/run-primitive.ts
@@ -88,8 +88,13 @@ export async function runAll(): Promise<void> {
   const filter = process.env.BASELINES?.split(",").map((s) => s.trim()).filter(Boolean);
   const baselines = filter
     ? allBaselines.filter((b) => filter.includes(b.name))
-    : // Default run: omit experimental sverklo-rerank from no-filter execution.
-      allBaselines.filter((b) => b.name !== "sverklo-rerank");
+    : // Default run: omit experimental baselines from no-filter execution.
+      // - sverklo-rerank: A/B test for ColBERT-style rerank (issue #29).
+      // - bifrost: real gateway integration, retrieval quality not yet
+      //   tuned (PR #67). Opt in with BASELINES=bifrost when the gateway
+      //   is reachable. Otherwise it would silently produce empty
+      //   predictions and skew the published bench numbers.
+      allBaselines.filter((b) => b.name !== "sverklo-rerank" && b.name !== "bifrost");
 
   const results: RunResult[] = [];
   const rawPath = join(outDir, "raw.jsonl");

--- a/benchmark/src/runner/run-primitive.ts
+++ b/benchmark/src/runner/run-primitive.ts
@@ -8,6 +8,7 @@ import { NaiveGrepBaseline } from "../baselines/naive-grep.ts";
 import { SmartGrepBaseline } from "../baselines/smart-grep.ts";
 import { SverkloBaseline } from "../baselines/sverklo.ts";
 import { JcodemunchBaseline } from "../baselines/jcodemunch.ts";
+import { BifrostBaseline } from "../baselines/gateway/bifrost.ts";
 import { GitNexusBaseline } from "../baselines/gitnexus.ts";
 import { SverkloRerankBaseline } from "../baselines/sverklo-rerank.ts";
 import { loadJsonl } from "../ground-truth/schema.ts";
@@ -78,6 +79,7 @@ export async function runAll(): Promise<void> {
     new SverkloBaseline(),
     new JcodemunchBaseline(),
     new GitNexusBaseline(),
+    new BifrostBaseline(),
     // Issue #29: A/B test against ColBERT-style rerank. Off by default
     // in the standard run (so npm run bench:quick output stays comparable
     // across releases) — opt in with BASELINES=sverklo-rerank.


### PR DESCRIPTION
This PR replaces the previous mock-only Bifrost benchmark implementation with a real OpenAI-compatible HTTP integration.

### What changed

* Added real Bifrost gateway communication using:

  * `/v1/models`
  * `/v1/chat/completions`
* Added model discovery during dataset setup
* Added timeout handling for inference calls
* Added structured prediction parsing for:

  * P1/P2 location tasks
  * P4 dependency tasks
  * P5 symbol/name tasks
* Added fallback-safe empty predictions on failures
* Removed hardcoded mock/static responses previously returned for every benchmark task

### Current status

This implementation is intended as an infrastructure-first integration and establishes a real execution path through a running Bifrost gateway.

The baseline is currently experimental regarding retrieval quality and prompt/context strategies. Current benchmark scores should not yet be interpreted as representative of final Bifrost performance.

### Future improvements

Planned follow-up work includes:

* configurable `BIFROST_BASE_URL`
* graceful skip behavior when gateway is unavailable
* improved prompt engineering
* repository-aware retrieval/context injection
* tool orchestration support
* more robust parsing for non-strict JSON outputs
* optional Docker-based reproducible setup

This PR focuses primarily on replacing the previous mock baseline with a genuine inference-backed integration.
