### PR TITLE
fix(embedding): validate Ollama response dim — Viraj re-report (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [0.25.2] — 2026-05-24
+
+### Fixed
+
+- **#66 — Ollama provider stored 384d vectors despite `dimensions: 1024` config (real-user repro: Viraj).** v0.25.0 wired `.sverklo.yaml` `embeddings.provider` into the factory so the Ollama provider was actually *selected*, but `OllamaProvider.embed()` blindly wrapped whatever Ollama returned into a `Float32Array` and pushed it into the indexer. When the configured model's true output dim disagreed with `embeddings.dimensions` (Viraj configured 1024 against a model that returned 384), the embed phase completed "successfully" — provider kept reporting 1024 dims, indexer wrote 384-dim vectors to SQLite, and `sverklo doctor` flagged the mismatch only after 6370 chunks of bad data were on disk. Fix in `src/indexer/embedding-providers.ts`: on every batch, compare the response vector length against the configured dim. If a user passed `embeddings.dimensions: N` and Ollama returns M ≠ N, throw fail-loud with the actual N and a fix-it hint pointing at the YAML field. The auto-detect path (no user-supplied dim) is unchanged. Regression test mocks Ollama returning 384d while YAML asks for 1024 and asserts `indexer.index()` rejects — fails on v0.25.1 source (verified by stashing the fix and re-running), passes with the fix.
+- **#66 (related) — `fingerprintOf` is defined but never called outside its own test.** The module header (line 22-23 of `embedding-providers.ts`) documents an "index startup checks stored provider against current config and triggers a rebuild" guarantee, but the code that would do that comparison and trigger the rebuild was never written. Tracking issue to be opened for v0.26.0; out of scope for this patch.
+
+---
+
 ## [0.25.0] — 2026-05-22
 
 ### Fixed

--- a/src/indexer/embedding-providers.test.ts
+++ b/src/indexer/embedding-providers.test.ts
@@ -97,3 +97,87 @@ describe("fingerprintOf", () => {
     expect(fp.dimensions).toBe(384);
   });
 });
+
+// Regression: issue #66. v0.25.0 fixed the YAML wiring so the Ollama
+// provider was actually *selected*, but the provider trusted the
+// configured `embeddings.dimensions` blindly and never compared it to
+// the actual response length. Users running a model whose true output
+// dim disagreed with their config (e.g. configured 1024, model returns
+// 384) ended up with 384-dim vectors stored in the index while
+// `provider.dimensions` kept reporting 1024. `sverklo doctor` flagged
+// the mismatch but the embed phase wrote the bad data first.
+//
+// The fix: on every embed() batch, if the configured dim is known and
+// the actual response dim disagrees, throw fail-loud. Better to abort
+// the index run than to persist vectors that misrepresent themselves.
+describe("OllamaProvider dimension validation (issue #66)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when Ollama returns vectors with a different dim than configured", async () => {
+    // Mock fetch: probe (/api/tags) succeeds, /api/embed returns 384-dim
+    // vectors despite the caller having configured 1024. This is the
+    // exact shape of Viraj's v0.25.1 failure.
+    global.fetch = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (u.endsWith("/api/embed")) {
+        return new Response(
+          JSON.stringify({ embeddings: [new Array(384).fill(0)] }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const p = await createEmbeddingProvider(
+      { SVERKLO_EMBEDDING_PROVIDER: "ollama" },
+      {
+        embeddings: {
+          provider: "ollama",
+          dimensions: 1024,
+          ollama: { baseUrl: "http://localhost:11434", model: "qwen3-embedding:0.6b" },
+        },
+      } as Parameters<typeof createEmbeddingProvider>[1]
+    );
+
+    // Factory should have selected ollama (not silently fallen back).
+    expect(p.name).toContain("ollama");
+    expect(p.dimensions).toBe(1024);
+
+    // The actual write path: provider.embed() must refuse rather than
+    // hand back 384-dim vectors that the indexer would persist.
+    await expect(p.embed(["hello world"])).rejects.toThrow(
+      /returned 384-dim vectors but the provider was configured for 1024-dim/
+    );
+  });
+
+  it("auto-detects dimensions when no explicit config is supplied", async () => {
+    // Inverse case: when the user does NOT pass `dimensions`, the
+    // provider should auto-detect from the response and not throw.
+    // Locks in the existing behavior so the #66 fix doesn't regress
+    // the auto-detect path.
+    global.fetch = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (u.endsWith("/api/embed")) {
+        return new Response(
+          JSON.stringify({ embeddings: [new Array(512).fill(0)] }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const p = await createEmbeddingProvider({ SVERKLO_EMBEDDING_PROVIDER: "ollama" });
+    const vecs = await p.embed(["hello"]);
+    expect(vecs).toHaveLength(1);
+    expect(vecs[0].length).toBe(512);
+    expect(p.dimensions).toBe(512);
+  });
+});

--- a/src/indexer/embedding-providers.ts
+++ b/src/indexer/embedding-providers.ts
@@ -283,10 +283,31 @@ class OllamaProvider implements EmbeddingProvider {
       }
       const json = (await res.json()) as OllamaEmbedResponse;
 
-      // Auto-detect dimensions from the first real response.
-      if (!this._dimensionsDetected && json.embeddings?.[0]?.length) {
-        this._dimensions = json.embeddings[0].length;
-        this._dimensionsDetected = true;
+      // Validate response dimensions. Two cases:
+      //   (a) user configured `embeddings.dimensions: N` — Ollama MUST
+      //       return N-dim vectors. If it returns something else, the
+      //       index would end up with vectors that don't match what the
+      //       provider claims via `.dimensions`, doctor would flag a
+      //       mismatch on every run, and similarity scoring would be
+      //       silently wrong. Throw fail-loud so the user fixes the
+      //       model or the config — better than persisting bad data.
+      //       (#66 root cause: pre-v0.25.2 we trusted the config blindly.)
+      //   (b) no user config — auto-detect from the first response, then
+      //       enforce stability for every subsequent batch in this run.
+      const actualLen = json.embeddings?.[0]?.length;
+      if (actualLen) {
+        if (!this._dimensionsDetected) {
+          this._dimensions = actualLen;
+          this._dimensionsDetected = true;
+        } else if (actualLen !== this._dimensions) {
+          throw new Error(
+            `Ollama model '${this.model}' returned ${actualLen}-dim vectors ` +
+              `but the provider was configured for ${this._dimensions}-dim. ` +
+              `Update embeddings.dimensions in .sverklo.yaml to ${actualLen}, ` +
+              `or switch to a model whose output matches the configured dimension. ` +
+              `(sverklo/sverklo#66)`
+          );
+        }
       }
 
       for (const emb of json.embeddings) {

--- a/src/indexer/indexer-provider-integration.test.ts
+++ b/src/indexer/indexer-provider-integration.test.ts
@@ -159,6 +159,70 @@ describe("Indexer + embedding provider integration", () => {
     }
   });
 
+  // Regression for issue #66 (v0.25.2). v0.25.0 fixed wiring but
+  // didn't validate Ollama's response dim against the configured one.
+  // Viraj's setup (`dimensions: 1024` + a model that returned 384)
+  // ended the embed phase "successfully" with 384-dim vectors in the
+  // index. The provider kept reporting 1024 dims; doctor flagged it
+  // after the fact, but by then 6370 chunks of bad data were written.
+  //
+  // This test mocks Ollama to return 384-dim vectors while the YAML
+  // requests 1024. The patched embed() throws → index() surfaces the
+  // failure. On the unpatched code, index() would complete silently
+  // and the embeddings table would contain 384-dim vectors.
+  it("fails loud when Ollama returns a different dim than configured (issue #66)", async () => {
+    delete process.env.SVERKLO_EMBEDDING_PROVIDER;
+    delete process.env.SVERKLO_OLLAMA_URL;
+
+    writeFileSync(
+      join(tmpRoot, ".sverklo.yaml"),
+      [
+        "embeddings:",
+        "  provider: ollama",
+        "  dimensions: 1024",
+        "  ollama:",
+        "    baseUrl: http://localhost:11434",
+        "    model: qwen3-embedding:0.6b",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    // Mock the wrong-dim response: 384 floats per chunk, regardless of
+    // how many inputs are in the batch.
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn(async (url: unknown, init?: unknown) => {
+      const u = String(url);
+      if (u.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (u.endsWith("/api/embed")) {
+        const body = JSON.parse((init as { body: string }).body);
+        const input: string[] = Array.isArray(body.input) ? body.input : [body.input];
+        return new Response(
+          JSON.stringify({
+            embeddings: input.map(() => new Array(384).fill(0)),
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const indexer = new Indexer(getProjectConfig(tmpRoot));
+      try {
+        await expect(indexer.index()).rejects.toThrow(
+          /returned 384-dim vectors but the provider was configured for 1024-dim/
+        );
+      } finally {
+        indexer.close();
+      }
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   // Regression for issue #59 (v0.25.0). The original wiring bug was
   // that Indexer.index() called createEmbeddingProvider() with no
   // arguments, so .sverklo.yaml `embeddings.provider` was a silent


### PR DESCRIPTION
## Summary

Viraj re-tested v0.25.1 and found the v0.25.0 #59 fix solved the YAML→factory wiring but did NOT resolve the user-visible failure: Ollama configured for 1024d, full 151s reindex visible in `--timing`, but doctor still reports `stored 384d × 6370 chunks`. This PR fixes the actual user-visible bug.

## Root cause

`OllamaProvider.embed()` only auto-detected vector dim when `!_dimensionsDetected`. The constructor flipped that flag to `true` whenever `opts.dimensions` was set. So for users with an explicit YAML config, validation was skipped on every batch — the provider claimed dim=1024 to the rest of sverklo while writing whatever Ollama returned (384d in Viraj's case) into the index. Storage layer is dim-agnostic by design (BLOB, no length check); the truncated vectors land silently.

## Fix

`OllamaProvider.embed()` now validates the response dim on every batch:
- **User configured a dim explicitly + Ollama returns something else** → throw fail-loud with actual-dim + `.sverklo.yaml` hint. Reindex exits non-zero instead of finishing with a misleading `✓ Done`.
- **No user dim** → existing auto-detect runs on first batch, subsequent batches enforce stability.

Fail-loud over silent-coerce so users either fix their YAML or pick a different model — both concrete actions named in the error message.

## Tests (Principle VI-compliant)

The agent verified the tests FAIL on the unpatched code by stashing the fix and re-running:
- `embedding-providers.test.ts`: 1 test failed (got 384-len `Float32Array` instead of a throw)
- `indexer-provider-integration.test.ts`: 1 test failed (`index()` resolved silently — Viraj's exact behavior)

Restoring the fix: all 18 pass. Full suite: 674 passed, 1 skipped.

## VI compliance audit

- **VI.1** (reproduce): partial — Ollama is installed locally but `qwen3-embedding:0.6b` isn't pulled. The integration test mocks the failure mode faithfully; the bug is in our code path, not Ollama's. Live repro against the published binary deferred to post-merge validation.
- **VI.2** (test in same commit): yes.
- **VI.3** (fails on unpatched): verified by stash + re-run.
- **VI.4** (validate against built artifact): will run after merge against `npm view sverklo version` confirming v0.25.2 publish. Will ping Viraj to re-test.
- **VI.5** (close issue against verified version): pending Viraj's re-test confirmation, then close #66 against v0.25.2.

## Not in scope

- `fingerprintOf` is defined at line 449 but never called outside its unit test. The header comment promises "auto-rebuild on provider change" — that wiring doesn't exist. Tracking issue for v0.26.0.
- Storage-layer length check: rejected as defense-in-depth; the provider boundary is the right place to catch this.
- Windows EBUSY-after-Claude-Code-exit (also in #66): separate MCP server lifecycle question, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)