### PR TITLE
feat(indexer): wire fingerprintOf — detect provider change, refuse stale index (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [0.26.0] — 2026-05-24
+
+### Added
+
+- **#69 — provider-change auto-detect + refuse-stale-index.** `fingerprintOf()` had existed since v0.24 but was only called from its own unit test — the indexer never compared it against anything, so switching `embeddings.provider` in `.sverklo.yaml` (e.g. `onnx` → `ollama`, or one Ollama model → another at the same dim) silently mixed vector spaces in one embeddings table. The same-dim case slipped past the v0.25 doctor diagnostic (it only inspected `length(vector)/4`). Wiring in this release:
+  - `src/storage/database.ts` exposes `getStoredFingerprint` / `setStoredFingerprint`, persisted under `meta.key = 'embedding_fingerprint'` (JSON blob, single row, same table as `data_version`).
+  - `Indexer.index()` computes the active fingerprint right after provider init, reads the stored one, and on disagreement throws with both fingerprints + `sverklo reindex --force` as the fix. The throw happens before any writes; the CLI exits non-zero. First index and pre-#69 databases fall through and stamp the current fingerprint.
+  - `sverklo doctor` adds an "embedding fingerprint" check that compares stored provider name against the configured one (prefix-match against `ollama:model`-style names) so a switch is surfaced even when both providers happen to share dimensions.
+  - Regression covered by `src/indexer/indexer-fingerprint.test.ts`: 5 storage unit tests + 4 integration tests asserting (a) fingerprint stamps on first index, (b) provider switch is rejected with the right error message, (c) the documented `clearIndex() + index()` recovery path works, and (d) legacy databases (no fingerprint row yet) upgrade silently on next index. The 4 integration tests fail on the v0.25.2 source (verified by stashing the indexer wiring and re-running) and pass with the wiring.
+
+---
+
 ## [0.25.2] — 2026-05-24
 
 ### Fixed

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -216,6 +216,55 @@ export function runDoctor(projectPath: string): void {
             });
           }
         }
+
+        // Issue #69: fingerprint check. The dim-only check above misses
+        // the case where two providers produce the SAME dim (e.g. an
+        // ONNX MiniLM 384d vs an Ollama nomic-embed-text 384d) — the
+        // vector spaces are incompatible but `length(vector)/4`
+        // matches. The stored fingerprint captures provider name +
+        // dims so we can flag the switch even when dims agree.
+        try {
+          const fpRow = probe
+            .prepare(
+              "SELECT value FROM meta WHERE key = 'embedding_fingerprint'"
+            )
+            .get() as { value: string } | undefined;
+          if (fpRow && embeddedCount > 0) {
+            const stored = JSON.parse(fpRow.value) as {
+              provider?: string;
+              dimensions?: number;
+            };
+            // configuredProvider from `.sverklo.yaml` is bare ("ollama")
+            // while the fingerprint stores the resolved name
+            // ("ollama:qwen3-embedding:0.6b"). Compare with a prefix
+            // match so a user who changed only the YAML model field
+            // still surfaces as a mismatch.
+            const providerMatches =
+              typeof stored.provider === "string" &&
+              (stored.provider === configuredProvider ||
+                stored.provider.startsWith(configuredProvider + ":") ||
+                configuredProvider === "default");
+            const dimsMatch =
+              configuredDims === undefined ||
+              stored.dimensions === configuredDims;
+            if (!providerMatches || !dimsMatch) {
+              checks.push({
+                name: "embedding fingerprint",
+                status: "fail",
+                message:
+                  `index was built with ${stored.provider} (${stored.dimensions}d) ` +
+                  `but config requests ${configuredProvider}` +
+                  (configuredDims ? ` (${configuredDims}d)` : "") +
+                  `. Switching providers without a rebuild mixes vector spaces.`,
+                fix: "sverklo reindex --force",
+              });
+            }
+          }
+        } catch {
+          // meta table missing or row malformed — pre-#69 db or
+          // first-index-not-yet-completed. The dim check above already
+          // covered the visible-symptom case; don't add noise.
+        }
       } finally {
         try { probe.close(); } catch { /* ignore */ }
       }

--- a/src/indexer/indexer-fingerprint.test.ts
+++ b/src/indexer/indexer-fingerprint.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Indexer } from "./indexer.js";
+import { getProjectConfig } from "../utils/config.js";
+import {
+  createDatabase,
+  getStoredFingerprint,
+  setStoredFingerprint,
+} from "../storage/database.js";
+
+// Issue #69: provider-change auto-detect.
+//
+// Before this patch, `fingerprintOf()` existed in embedding-providers.ts
+// but was only ever called by its own unit test. Switching providers in
+// `.sverklo.yaml` (e.g. onnx -> ollama, or one ollama model -> another)
+// silently mixed vector spaces inside the same embeddings table — the
+// indexer carried on with the new provider on top of the old vectors,
+// degrading search quality with no visible signal.
+//
+// The fix wires three things together:
+//   1. Storage helpers `getStoredFingerprint` / `setStoredFingerprint`
+//      reading/writing the `meta` table key 'embedding_fingerprint'.
+//   2. `Indexer.index()` reads the stored fingerprint before any writes
+//      and refuses to update if it disagrees with the active provider.
+//      It also stamps the current fingerprint when there's no stored
+//      one (first index, legacy upgrade).
+//   3. `sverklo doctor` surfaces the disagreement as a check-fail with
+//      `sverklo reindex --force` as the fix.
+//
+// Each test below was verified to FAIL on the unpatched code by
+// stashing the wiring and re-running (see CHANGELOG entry).
+
+describe("storage fingerprint helpers", () => {
+  it("returns null on a fresh database with no stored fingerprint", () => {
+    const db = createDatabase(":memory:");
+    expect(getStoredFingerprint(db)).toBeNull();
+    db.close();
+  });
+
+  it("round-trips through the meta table", () => {
+    const db = createDatabase(":memory:");
+    setStoredFingerprint(db, { provider: "ollama:nomic-embed-text", dimensions: 768 });
+    expect(getStoredFingerprint(db)).toEqual({
+      provider: "ollama:nomic-embed-text",
+      dimensions: 768,
+    });
+    db.close();
+  });
+
+  it("overwrites on second set (ON CONFLICT)", () => {
+    const db = createDatabase(":memory:");
+    setStoredFingerprint(db, { provider: "default", dimensions: 384 });
+    setStoredFingerprint(db, { provider: "openai:text-embedding-3-small", dimensions: 1536 });
+    expect(getStoredFingerprint(db)).toEqual({
+      provider: "openai:text-embedding-3-small",
+      dimensions: 1536,
+    });
+    db.close();
+  });
+
+  it("returns null when stored JSON is malformed", () => {
+    const db = createDatabase(":memory:");
+    // Bypass setStoredFingerprint to inject garbage. Mirrors what a
+    // partial-write or downgrade-then-upgrade sequence might leave.
+    db.prepare(
+      "INSERT INTO meta (key, value) VALUES ('embedding_fingerprint', 'not-json')"
+    ).run();
+    expect(getStoredFingerprint(db)).toBeNull();
+    db.close();
+  });
+
+  it("returns null when stored JSON has wrong shape", () => {
+    const db = createDatabase(":memory:");
+    db.prepare(
+      "INSERT INTO meta (key, value) VALUES ('embedding_fingerprint', ?)"
+    ).run(JSON.stringify({ provider: "ollama" })); // missing dimensions
+    expect(getStoredFingerprint(db)).toBeNull();
+    db.close();
+  });
+});
+
+describe("Indexer fingerprint wiring (issue #69)", () => {
+  let tmpRoot: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "sverklo-fingerprint-"));
+    mkdirSync(join(tmpRoot, "src"), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, "src", "a.ts"),
+      "export function hello() { return 'world'; }\n",
+      "utf-8"
+    );
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {}
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("SVERKLO_") && !(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (k.startsWith("SVERKLO_")) process.env[k] = v;
+    }
+  });
+
+  it("stamps the fingerprint after the first successful index", async () => {
+    delete process.env.SVERKLO_EMBEDDING_PROVIDER;
+    const cfg = getProjectConfig(tmpRoot);
+
+    const indexer = new Indexer(cfg);
+    try {
+      await indexer.index();
+    } finally {
+      indexer.close();
+    }
+
+    // Reopen the DB read-only and confirm the fingerprint row exists.
+    const db = createDatabase(cfg.dbPath);
+    try {
+      const fp = getStoredFingerprint(db);
+      expect(fp).not.toBeNull();
+      expect(fp!.provider).toBe("default");
+      expect(fp!.dimensions).toBe(384);
+    } finally {
+      db.close();
+    }
+  });
+
+  // Core regression: this is the failure mode #69 was filed for.
+  // Without the wiring, the second index() call silently succeeds and
+  // mixes 384d vectors with 1024d vectors in the same embeddings table.
+  it("refuses to update when the stored fingerprint disagrees with the current provider", async () => {
+    delete process.env.SVERKLO_EMBEDDING_PROVIDER;
+    delete process.env.SVERKLO_OLLAMA_URL;
+
+    const cfg = getProjectConfig(tmpRoot);
+
+    // First index: default ONNX, 384d.
+    const first = new Indexer(cfg);
+    try {
+      await first.index();
+    } finally {
+      first.close();
+    }
+
+    // Confirm the first run stamped a fingerprint.
+    {
+      const db = createDatabase(cfg.dbPath);
+      try {
+        expect(getStoredFingerprint(db)).toEqual({
+          provider: "default",
+          dimensions: 384,
+        });
+      } finally {
+        db.close();
+      }
+    }
+
+    // Now switch the config to Ollama at 1024d. Mock fetch so the
+    // factory init() succeeds and reports a 1024-dim provider.
+    writeFileSync(
+      join(tmpRoot, ".sverklo.yaml"),
+      [
+        "embeddings:",
+        "  provider: ollama",
+        "  dimensions: 1024",
+        "  ollama:",
+        "    baseUrl: http://localhost:11434",
+        "    model: qwen3-embedding:0.6b",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn(async (url: unknown, init?: unknown) => {
+      const u = String(url);
+      if (u.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (u.endsWith("/api/embed")) {
+        const body = JSON.parse((init as { body: string }).body);
+        const input: string[] = Array.isArray(body.input) ? body.input : [body.input];
+        return new Response(
+          JSON.stringify({
+            embeddings: input.map(() => new Array(1024).fill(0)),
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const second = new Indexer(cfg);
+      try {
+        await expect(second.index()).rejects.toThrow(
+          /Embedding provider change detected/
+        );
+        // Error message must mention both fingerprints and the fix.
+        await expect(second.index()).rejects.toThrow(/default \(384d\)/);
+        await expect(second.index()).rejects.toThrow(/ollama.*\(1024d\)/);
+        await expect(second.index()).rejects.toThrow(/sverklo reindex --force/);
+      } finally {
+        second.close();
+      }
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it("succeeds on the path: index -> clearIndex -> index (rebuild with new provider)", async () => {
+    delete process.env.SVERKLO_EMBEDDING_PROVIDER;
+    delete process.env.SVERKLO_OLLAMA_URL;
+
+    const cfg = getProjectConfig(tmpRoot);
+
+    // First index: default ONNX, 384d. Stamps fingerprint.
+    const first = new Indexer(cfg);
+    try {
+      await first.index();
+    } finally {
+      first.close();
+    }
+
+    // Switch config to Ollama 1024d.
+    writeFileSync(
+      join(tmpRoot, ".sverklo.yaml"),
+      [
+        "embeddings:",
+        "  provider: ollama",
+        "  dimensions: 1024",
+        "  ollama:",
+        "    baseUrl: http://localhost:11434",
+        "    model: qwen3-embedding:0.6b",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn(async (url: unknown, init?: unknown) => {
+      const u = String(url);
+      if (u.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (u.endsWith("/api/embed")) {
+        const body = JSON.parse((init as { body: string }).body);
+        const input: string[] = Array.isArray(body.input) ? body.input : [body.input];
+        return new Response(
+          JSON.stringify({
+            embeddings: input.map(() => new Array(1024).fill(0)),
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const second = new Indexer(cfg);
+      try {
+        // The expected user workflow: refusal, then reindex --force,
+        // which calls clearIndex() then index() fresh.
+        const cleared = second.clearIndex();
+        expect(cleared.failed).toHaveLength(0);
+        // After clearIndex the DB file is gone (and reinitialized
+        // empty), so no stored fingerprint. Second index() runs to
+        // completion and stamps the new fingerprint.
+        await second.index();
+        expect(second.embeddingProviderName).toContain("ollama");
+        expect(second.embeddingDimensions).toBe(1024);
+      } finally {
+        second.close();
+      }
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    // Re-open and confirm the stamped fingerprint reflects the new provider.
+    const db = createDatabase(cfg.dbPath);
+    try {
+      const fp = getStoredFingerprint(db);
+      expect(fp).not.toBeNull();
+      expect(fp!.provider).toMatch(/^ollama:/);
+      expect(fp!.dimensions).toBe(1024);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("legacy upgrade: stamps fingerprint on first index against a pre-#69 db with no stored fingerprint", async () => {
+    delete process.env.SVERKLO_EMBEDDING_PROVIDER;
+    const cfg = getProjectConfig(tmpRoot);
+
+    // Simulate a pre-#69 database: create the DB and write some
+    // synthetic embeddings (no fingerprint row).
+    const seed = createDatabase(cfg.dbPath);
+    // No setStoredFingerprint call. Just confirm the helper sees null.
+    expect(getStoredFingerprint(seed)).toBeNull();
+    seed.close();
+
+    // Now run a normal index against that DB. Should NOT throw —
+    // there's nothing to compare against — and SHOULD stamp the
+    // current fingerprint for next run's benefit.
+    const indexer = new Indexer(cfg);
+    try {
+      await indexer.index();
+    } finally {
+      indexer.close();
+    }
+
+    const db = createDatabase(cfg.dbPath);
+    try {
+      expect(getStoredFingerprint(db)).toEqual({
+        provider: "default",
+        dimensions: 384,
+      });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -5,6 +5,8 @@ import {
   createDatabase,
   getDataVersion,
   setDataVersion,
+  getStoredFingerprint,
+  setStoredFingerprint,
   transaction,
   CURRENT_DATA_VERSION,
 } from "../storage/database.js";
@@ -28,6 +30,7 @@ import { describeChunk } from "./describer.js";
 import { embed as legacyEmbed, initEmbedder } from "./embedder.js";
 import {
   createEmbeddingProvider,
+  fingerprintOf,
   type EmbeddingProvider,
 } from "./embedding-providers.js";
 import { buildGraph } from "./graph-builder.js";
@@ -345,6 +348,52 @@ export class Indexer implements IndexFiles, IndexCode, IndexGraph, IndexMemory, 
         );
       }
       phaseEnd("provider_init", tProviderInit);
+
+      // Issue #69: provider-change auto-detect.
+      //
+      // Compare the active provider's fingerprint against the one
+      // persisted by the last successful index. If they disagree AND
+      // the on-disk index is non-empty, refuse to incrementally update
+      // — otherwise we'd mix vector spaces inside one embeddings table
+      // (the same silent-degradation class as #59 / #66, just one layer
+      // up). Throwing here means `index()` rejects, the CLI exits
+      // non-zero, and the user sees both fingerprints + the reindex
+      // command they need to run.
+      //
+      // First-index path (empty store, no stored fingerprint) and
+      // legacy-upgrade path (non-empty store from a pre-#69 sverklo
+      // with no stored fingerprint) both fall through and stamp the
+      // current fingerprint after a successful index. The legacy path
+      // implicitly trusts that the existing vectors match the current
+      // provider — they were written by the same provider config that's
+      // active now, modulo the user changing config between sverklo
+      // versions, which is exactly what they're upgrading to detect on
+      // the NEXT run.
+      const currentFingerprint = fingerprintOf(this.embeddingProvider);
+      const storedFingerprint = getStoredFingerprint(this.db);
+      if (
+        storedFingerprint &&
+        (storedFingerprint.provider !== currentFingerprint.provider ||
+          storedFingerprint.dimensions !== currentFingerprint.dimensions)
+      ) {
+        const oldFp = `${storedFingerprint.provider} (${storedFingerprint.dimensions}d)`;
+        const newFp = `${currentFingerprint.provider} (${currentFingerprint.dimensions}d)`;
+        // `finally` below clears `this.indexing`; let the error propagate.
+        throw new Error(
+          `Embedding provider change detected — refusing to update index.\n` +
+            `  Stored:    ${oldFp}\n` +
+            `  Configured: ${newFp}\n` +
+            `Mixing providers in the same index produces inconsistent vector spaces and ` +
+            `silently degrades search quality. Run \`sverklo reindex --force\` to rebuild ` +
+            `the index with the new provider.`
+        );
+      }
+
+      // Stamp the current fingerprint. Idempotent — no-op when stored
+      // already matches. Done here (not at the end of index()) so even
+      // the no-op "index is up to date" path leaves a stamped meta row
+      // for first-time + legacy-upgrade users.
+      setStoredFingerprint(this.db, currentFingerprint);
 
       // 1. Discover files
       const tDiscover = phaseStart();

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -408,6 +408,44 @@ export function setDataVersion(db: Database, version: number): void {
 }
 
 /**
+ * Embedding fingerprint persisted to `meta` so the indexer can detect
+ * silent provider/dimension changes across runs (issue #69). Stored as
+ * JSON because `EmbeddingFingerprint` may grow new fields. Shape mirrors
+ * `EmbeddingFingerprint` in embedding-providers.ts — we re-declare it as
+ * a plain record here to keep storage/ free of indexer/ imports.
+ */
+export type StoredFingerprint = { provider: string; dimensions: number };
+
+export function getStoredFingerprint(db: Database): StoredFingerprint | null {
+  try {
+    const row = db
+      .prepare("SELECT value FROM meta WHERE key = 'embedding_fingerprint'")
+      .get() as { value: string } | undefined;
+    if (!row) return null;
+    const parsed = JSON.parse(row.value) as Partial<StoredFingerprint>;
+    if (
+      typeof parsed.provider !== "string" ||
+      typeof parsed.dimensions !== "number"
+    ) {
+      return null;
+    }
+    return { provider: parsed.provider, dimensions: parsed.dimensions };
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredFingerprint(
+  db: Database,
+  fp: StoredFingerprint
+): void {
+  db.prepare(
+    "INSERT INTO meta (key, value) VALUES ('embedding_fingerprint', ?) " +
+      "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+  ).run(JSON.stringify({ provider: fp.provider, dimensions: fp.dimensions }));
+}
+
+/**
  * BEGIN / COMMIT / ROLLBACK helper. better-sqlite3 had `db.transaction(fn)`
  * built in; node:sqlite doesn't, so we wrap the pattern explicitly.
  * Used by Indexer.index() for the bulk-insert path.


### PR DESCRIPTION
## Summary

Closes #69. `fingerprintOf()` has existed in `src/indexer/embedding-providers.ts` since the pluggable-provider feature (issue #9) but was only called by its own unit test. The promised auto-detect-and-refuse-stale-index behavior in the module header never actually landed. So switching providers in `.sverklo.yaml` silently mixed vector spaces, with users finding out via degraded search quality.

## How it works

After provider lazy-init but BEFORE file discover, `Indexer.index()`:
1. Computes current fingerprint via `fingerprintOf(provider)`.
2. Reads stored fingerprint from the `meta` table.
3. If null (first index or pre-#69 legacy upgrade) → stamp current, continue.
4. If match → continue.
5. If mismatch → throw with both fingerprints + `sverklo reindex --force` hint. `index()` rejects before any writes happen.

## Storage choice

Reused the existing `meta` k/v table (same pattern as `data_version`) — JSON-encoded `StoredFingerprint` under `embedding_fingerprint`. Zero schema changes, no migration burden.

## Doctor

Added an `embedding fingerprint` sub-check inside the existing embedding-index probe. Prefix-match on provider names (`stored.provider.startsWith(configured + ":")`) so user-facing `provider: ollama` matches stored `ollama:qwen3-embedding:0.6b`. Catches the case the v0.25.0 #59 dim-only check misses: two providers producing identical dims.

## Tests (Principle VI compliant)

9 new tests in `src/indexer/indexer-fingerprint.test.ts`:

- 5 storage unit tests (round-trip, overwrite, malformed-JSON tolerance, wrong-shape tolerance, fresh-db null)
- 4 integration tests (first-index stamping, refusal-on-provider-switch with error content check, clearIndex+index recovery, legacy-upgrade path)

The agent verified the 4 integration tests **fail on unpatched code** (stashed `src/indexer/indexer.ts`, re-ran, saw the expected failures) and **pass on patched code** (restored, all 9 pass). That's Principle VI.3 satisfied.

Full suite: 686 passed, 1 skipped, 0 failed across 76 test files.

## Migration impact

Pre-#69 users are NOT forced to reindex. First post-upgrade `index()` silently stamps the current configured provider as the baseline. Only a *subsequent* config change triggers the refusal.

Trade-off: a user who silently switched providers pre-v0.26.0 and never reindexed gets trusted with whatever's currently configured. The alternative — forcing every existing user to reindex on upgrade — was rejected as too disruptive.

## Constitution check

- **I — Local-first**: ✅ No new network paths.
- **II — Dogfood**: ✅ Will run sverklo on its own repo before tagging.
- **III — Public benchmarks**: N/A (no public claim depending on this).
- **IV — Test-first CI**: ✅ Tests added before merge, fail-on-unpatched verified.
- **V — Ship small**: ✅ One feature, one file's-worth of wiring + a focused test file.
- **VI — Validate the fix, then ship**: ✅ Agent verified VI.3 via stash + re-run. VI.4 will run post-merge against the published v0.26.0 artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)