### PR TITLE
feat(tools): drop sverklo_ prefix, soft transition aliases (#71)

### DIFF
--- a/bin/sverklo.ts
+++ b/bin/sverklo.ts
@@ -932,7 +932,7 @@ if (command === "telemetry") {
     console.log("  os          darwin / linux / win32");
     console.log("  node_major  the Node major version sverklo is running on");
     console.log("  event       one of 17 fixed event types");
-    console.log("  tool        sverklo_* tool name (when applicable)");
+    console.log("  tool        sverklo tool name (when applicable)");
     console.log("  outcome     ok / error / timeout");
     console.log("  duration_ms tool execution time");
     console.log("");
@@ -1144,7 +1144,7 @@ if (command === "profile") {
       console.log(`             ${tools.map((t: string) => t.replace(/^sverklo_/, "")).join(", ")}`);
       console.log();
     }
-    console.log("  full        36 tools  (all sverklo_* tools — default)");
+    console.log("  full        36 tools  (every first-party sverklo tool — default)");
     console.log("\n  Set with: SVERKLO_PROFILE=core sverklo init");
     console.log("  Or in .sverklo.yaml: profile: core");
     console.log("  See: https://sverklo.com/blog/we-already-shipped-mcp-code-mode/\n");
@@ -1178,8 +1178,14 @@ if (command === "profile") {
     // Structured doc — use it directly. The --days window doesn't apply
     // to cumulative stats; we use the full lifetime instead, and tell
     // the user when the doc started accumulating.
+    //
+    // v0.28.0: canonicalize legacy `sverklo_*` names in historical stats
+    // files so they collapse onto the new short names (`sverklo_search`
+    // + `search` → `search`). Without this, a long-running user's stats
+    // would show duplicate rows after the rename.
     for (const [tool, stat] of Object.entries(structuredStats.tools)) {
-      counts[tool] = stat.calls;
+      const canon = tool.startsWith("sverklo_") ? tool.slice("sverklo_".length) : tool;
+      counts[canon] = (counts[canon] || 0) + stat.calls;
     }
     total = structuredStats.totalCalls;
     const sinceStr = new Date(structuredStats.startedAt).toISOString().slice(0, 10);
@@ -1201,7 +1207,10 @@ if (command === "profile") {
       process.exit(0);
     }
     for (const c of calls) {
-      const tool = String(c.detail.tool);
+      const raw = String(c.detail.tool);
+      // v0.28.0: collapse legacy `sverklo_*` rows onto canonical names so
+      // upgraded users don't see split-personality stats.
+      const tool = raw.startsWith("sverklo_") ? raw.slice("sverklo_".length) : raw;
       counts[tool] = (counts[tool] || 0) + 1;
     }
     total = calls.length;
@@ -1218,8 +1227,7 @@ if (command === "profile") {
   console.log("  " + "-".repeat(70));
   for (const [tool, n] of ranked) {
     const pct = ((n / total) * 100).toFixed(1) + "%";
-    const display = tool.startsWith("sverklo_") ? tool : tool;
-    console.log("  " + display.padEnd(38) + String(n).padStart(10) + pct.padStart(10));
+    console.log("  " + tool.padEnd(38) + String(n).padStart(10) + pct.padStart(10));
   }
   console.log("  " + "-".repeat(70));
 
@@ -1230,6 +1238,15 @@ if (command === "profile") {
   const profileOrder: string[] = ["core", "nav", "review", "lean", "research"];
   type ProfileFit = { name: string; size: number; coveragePct: number; missing: string[] };
   const fits: ProfileFit[] = [];
+  // v0.28.0: first-party tools no longer carry a `sverklo_` prefix, so
+  // "missing from profile" is anyone-not-in-profile minus the Zilliz
+  // compat aliases (recorded but not first-party).
+  const COMPAT_ALIASES = new Set([
+    "index_codebase",
+    "search_code",
+    "clear_index",
+    "get_indexing_status",
+  ]);
   for (const name of profileOrder) {
     const profileTools = PROFILES[name];
     if (!profileTools) continue;
@@ -1238,7 +1255,7 @@ if (command === "profile") {
     const missing: string[] = [];
     for (const [tool, n] of ranked) {
       if (profileSet.has(tool)) covered += n;
-      else if (tool.startsWith("sverklo_")) missing.push(tool);
+      else if (!COMPAT_ALIASES.has(tool)) missing.push(tool);
     }
     fits.push({ name, size: profileTools.length, coveragePct: covered / total, missing });
   }

--- a/src/audit-prompt.ts
+++ b/src/audit-prompt.ts
@@ -24,14 +24,14 @@ Follow the hybrid workflow — prefer sverklo tools where they're the sharpest i
 
 ## Phase 1 — Discovery (prefer sverklo)
 
-1. \`sverklo_overview\` — structural map of the codebase, ranked by importance. Identify hub files and large files first.
-2. \`sverklo_audit\` — one-call pass for god nodes, hub files, and dead-code candidates. Treat this as your seed list.
-3. \`sverklo_search\` — semantic queries for anti-patterns you can describe in English but not regex cleanly (e.g. "swallowed exceptions", "silent failure returning null", "unsafe narrowing cast").
+1. \`overview\` — structural map of the codebase, ranked by importance. Identify hub files and large files first.
+2. \`audit\` — one-call pass for god nodes, hub files, and dead-code candidates. Treat this as your seed list.
+3. \`search\` — semantic queries for anti-patterns you can describe in English but not regex cleanly (e.g. "swallowed exceptions", "silent failure returning null", "unsafe narrowing cast").
 
 ## Phase 2 — Verify dead code and usage (sverklo wins here)
 
-4. \`sverklo_refs <symbol>\` — prove a method, class, or constant really has zero callers before you delete it. Grep can't match this with certainty because it misses reflective/string-based calls that the symbol graph catches.
-5. \`sverklo_deps <file>\` — map the dependency fan-in of suspicious hub files.
+4. \`refs <symbol>\` — prove a method, class, or constant really has zero callers before you delete it. Grep can't match this with certainty because it misses reflective/string-based calls that the symbol graph catches.
+5. \`deps <file>\` — map the dependency fan-in of suspicious hub files.
 
 ## Phase 3 — Exact patterns (built-in wins here)
 
@@ -51,7 +51,7 @@ Follow the hybrid workflow — prefer sverklo tools where they're the sharpest i
 
 - Every finding gets: file path, line numbers, severity, one-sentence fix.
 - Don't report style nits. Report things that would hurt in production.
-- If a finding relies on "this symbol is unused", verify with \`sverklo_refs\` before reporting it.
+- If a finding relies on "this symbol is unused", verify with \`refs\` before reporting it.
 - If a finding relies on "this pattern appears N times", verify with \`Grep\` count before reporting it.
 - Stop at 8–12 findings. More than that is noise.
 
@@ -65,13 +65,13 @@ Follow the hybrid workflow:
 ## Phase 1 — Understand the diff
 
 1. \`git diff <base>...HEAD --stat\` and \`git log --oneline <base>...HEAD\` — structural shape of the change.
-2. \`sverklo_review_diff\` — risk-scored review order. Read the highest-risk files first.
-3. \`sverklo_diff_search\` — semantic search scoped to the changed surface.
+2. \`review_diff\` — risk-scored review order. Read the highest-risk files first.
+3. \`diff_search\` — semantic search scoped to the changed surface.
 
 ## Phase 2 — Blast radius (sverklo wins here)
 
-4. For each modified symbol, \`sverklo_refs <symbol>\` and \`sverklo_impact <symbol>\` to see who depends on it. Flag silent behavior changes on high-fan-in symbols.
-5. \`sverklo_test_map\` — which tests cover the changed symbols? Flag modified production code with no test changes.
+4. For each modified symbol, \`refs <symbol>\` and \`impact <symbol>\` to see who depends on it. Flag silent behavior changes on high-fan-in symbols.
+5. \`test_map\` — which tests cover the changed symbols? Flag modified production code with no test changes.
 
 ## Phase 3 — Read the changed files line by line (built-in wins here)
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -464,8 +464,13 @@ export function runDoctor(projectPath: string): void {
   if (agentsExists || claudeExists) {
     const agentsContent = agentsExists ? readFileSync(agentsFilePath, "utf-8") : "";
     const claudeContent = claudeExists ? readFileSync(claudeFilePath, "utf-8") : "";
-    const agentsHasSnippet = agentsContent.includes("sverklo_search");
-    const claudeHasSnippet = claudeContent.includes("sverklo_search");
+    // v0.28.0: snippet body no longer contains literal `sverklo_search`
+    // (tools were renamed). Detect via the heading instead, falling back
+    // to the legacy token for pre-v0.28 snippets users may still have.
+    const hasSverkloSnippet = (content: string): boolean =>
+      /^##\s+Sverklo\b/m.test(content) || content.includes("sverklo_search");
+    const agentsHasSnippet = hasSverkloSnippet(agentsContent);
+    const claudeHasSnippet = hasSverkloSnippet(claudeContent);
     const claudeDelegatesToAgents = claudeExists && /agents\.md/i.test(claudeContent);
 
     if (agentsExists && claudeExists && claudeHasSnippet && !agentsHasSnippet && claudeDelegatesToAgents) {
@@ -509,7 +514,10 @@ export function runDoctor(projectPath: string): void {
   const copilotExists = existsSync(copilotPath);
   if (copilotExists) {
     const copilotContent = readFileSync(copilotPath, "utf-8");
-    const hasSnippet = copilotContent.includes("sverklo_search");
+    // v0.28.0: accept both new (heading) and legacy (`sverklo_search`) markers.
+    const hasSnippet =
+      /^##\s+Sverklo\b/m.test(copilotContent) ||
+      copilotContent.includes("sverklo_search");
     if (hasSnippet) {
       checks.push({
         name: "Copilot prefer-sverklo",
@@ -599,7 +607,7 @@ export function runDoctor(projectPath: string): void {
     checks.push({
       name: "memory journal",
       status: "ok",
-      message: "not created yet (normal — appears on the first sverklo_remember call)",
+      message: "not created yet (normal — appears on the first `remember` call)",
     });
   }
 
@@ -607,7 +615,11 @@ export function runDoctor(projectPath: string): void {
   const claudeMdPath = join(projectPath, "CLAUDE.md");
   if (existsSync(claudeMdPath)) {
     const content = readFileSync(claudeMdPath, "utf-8");
-    if (content.includes("sverklo_search")) {
+    // v0.28.0: accept both new (heading) and legacy (`sverklo_search`) markers.
+    if (
+      /^##\s+Sverklo\b/m.test(content) ||
+      content.includes("sverklo_search")
+    ) {
       checks.push({
         name: "CLAUDE.md",
         status: "ok",
@@ -630,7 +642,7 @@ export function runDoctor(projectPath: string): void {
     });
   }
 
-  // 7. MCP round-trip: initialize → tools/list → tools/call sverklo_status.
+  // 7. MCP round-trip: initialize → tools/list → tools/call `status`.
   //    A passing handshake alone is not proof Claude Code can actually USE
   //    sverklo — it only proves the binary speaks JSON-RPC. The dispatch
   //    probe runs the same three calls Claude Code makes on every fresh
@@ -661,7 +673,7 @@ export function runDoctor(projectPath: string): void {
       jsonrpc: "2.0" as const,
       id: 3,
       method: "tools/call",
-      params: { name: "sverklo_status", arguments: {} },
+      params: { name: "status", arguments: {} },
     };
     const input =
       [initReq, initializedNote, listReq, callReq]
@@ -743,24 +755,24 @@ export function runDoctor(projectPath: string): void {
       }
 
       // 7b. tools/list response (id=2) — proves the server advertises
-      //     sverklo_status; if Claude Code can read this, it can route.
+      //     the `status` tool; if Claude Code can read this, it can route.
       const listResp = responses.get(2) as
         | { result?: { tools?: Array<{ name?: string }> }; error?: { message?: string } }
         | undefined;
       const advertised = listResp?.result?.tools?.map((t) => t.name).filter(Boolean) ?? [];
       if (advertised.length > 0) {
-        const hasStatus = advertised.includes("sverklo_status");
+        const hasStatus = advertised.includes("status");
         if (hasStatus) {
           checks.push({
             name: "MCP tools/list",
             status: "ok",
-            message: `${advertised.length} tool${advertised.length === 1 ? "" : "s"} advertised (sverklo_status present)`,
+            message: `${advertised.length} tool${advertised.length === 1 ? "" : "s"} advertised (status present)`,
           });
         } else {
           checks.push({
             name: "MCP tools/list",
             status: "warn",
-            message: `${advertised.length} tools advertised but sverklo_status missing — profile may be filtering it`,
+            message: `${advertised.length} tools advertised but status tool missing — profile may be filtering it`,
             fix: "unset SVERKLO_PROFILE or use SVERKLO_PROFILE=core",
           });
         }
@@ -778,7 +790,7 @@ export function runDoctor(projectPath: string): void {
         });
       }
 
-      // 7c. tools/call sverklo_status (id=3) — proves dispatch end-to-end.
+      // 7c. tools/call `status` (id=3) — proves dispatch end-to-end.
       const callResp = responses.get(3) as
         | {
             result?: { content?: Array<{ type?: string; text?: string }>; isError?: boolean };
@@ -791,7 +803,7 @@ export function runDoctor(projectPath: string): void {
         checks.push({
           name: "MCP tools/call",
           status: "ok",
-          message: `sverklo_status returned ${firstText.length} chars — dispatch round-trip works`,
+          message: `status returned ${firstText.length} chars — dispatch round-trip works`,
         });
       } else if (callResp?.error?.message) {
         checks.push({

--- a/src/init-global-cli.test.ts
+++ b/src/init-global-cli.test.ts
@@ -55,8 +55,10 @@ describe("CLI: sverklo init --global (#72)", () => {
     const codexGlobal = join(tmpHome, ".codex", "AGENTS.md");
     expect(existsSync(claudeGlobal)).toBe(true);
     expect(existsSync(codexGlobal)).toBe(true);
-    expect(readFileSync(claudeGlobal, "utf-8")).toContain("sverklo_search");
-    expect(readFileSync(codexGlobal, "utf-8")).toContain("sverklo_search");
+    // v0.28.0: snippet was renamed; check for the heading marker instead
+    // of the legacy `sverklo_search` literal.
+    expect(readFileSync(claudeGlobal, "utf-8")).toMatch(/^##\s+Sverklo\b/m);
+    expect(readFileSync(codexGlobal, "utf-8")).toMatch(/^##\s+Sverklo\b/m);
   });
 
   it("registers the project in the global registry", () => {

--- a/src/init-global.test.ts
+++ b/src/init-global.test.ts
@@ -47,7 +47,8 @@ describe("writeGlobalInstructionsTo — issue #72", () => {
     expect(existsSync(target.path)).toBe(true);
     const content = readFileSync(target.path, "utf-8");
     expect(content).toContain("Sverklo");
-    expect(content).toContain("sverklo_search");
+    // v0.28.0: heading marker replaces the legacy `sverklo_search` literal.
+    expect(content).toMatch(/^##\s+Sverklo\b/m);
   });
 
   it("appends to an existing file that lacks the snippet", () => {
@@ -58,7 +59,8 @@ describe("writeGlobalInstructionsTo — issue #72", () => {
     expect(result.action).toBe("append");
     const content = readFileSync(target.path, "utf-8");
     expect(content).toContain("# my global rules");
-    expect(content).toContain("sverklo_search");
+    // v0.28.0: heading marker replaces the legacy `sverklo_search` literal.
+    expect(content).toMatch(/^##\s+Sverklo\b/m);
   });
 
   it("is idempotent: a second call against the same file is a no-op skip (literal sentinel)", () => {
@@ -133,16 +135,24 @@ describe("addSverkloToGitignore — extracted helper from initProject", () => {
   });
 });
 
-// Sanity: the snippet shared with initProject still contains the
-// sentinel string our idempotency detector looks for. If someone
-// rewrites SVERKLO_SNIPPET without "sverklo_search" in it, both
-// initProject's and initGlobal's "already present" detection break.
+// Sanity: the snippet shared with initProject must still match the
+// idempotency detector. v0.28.0 (issue #71) dropped the `sverklo_` prefix
+// from every tool name, so the literal `sverklo_search` is no longer in
+// the snippet body — the `## Sverklo` heading is now the primary marker.
+// The literal-sentinel path is still wired into the writers to detect
+// PRE-v0.28 snippets in user repos, so we don't double-inject on upgrade.
 describe("SVERKLO_SNIPPET sentinel invariant", () => {
-  it("contains the literal sentinel `sverklo_search`", () => {
-    expect(SVERKLO_SNIPPET).toContain("sverklo_search");
+  it("contains a `## Sverklo` heading for the heading sentinel", () => {
+    expect(SVERKLO_SNIPPET).toMatch(/^##\s+Sverklo\b/m);
   });
 
-  it("contains a `## Sverklo` heading for the secondary sentinel", () => {
-    expect(SVERKLO_SNIPPET).toMatch(/^##\s+Sverklo\b/m);
+  it("references the canonical (un-prefixed) tool names", () => {
+    // Spot-check: the snippet should advertise the renamed tools.
+    // If the rename ever regresses the snippet, agents written against
+    // v0.28+ skills will trip the deprecation warning on every call.
+    expect(SVERKLO_SNIPPET).toContain("`search`");
+    expect(SVERKLO_SNIPPET).toContain("`lookup`");
+    expect(SVERKLO_SNIPPET).toContain("`overview`");
+    expect(SVERKLO_SNIPPET).not.toContain("`sverklo_search`");
   });
 });

--- a/src/init.ts
+++ b/src/init.ts
@@ -20,23 +20,23 @@ This project has the sverklo MCP server installed. Sverklo is a code-intelligenc
 
 ### Always Do
 
-- **MUST call \`sverklo_overview\` before exploring an unfamiliar directory.** It returns the PageRank-ranked map of the codebase in one call — much cheaper than \`ls\` + \`Read\` loops.
-- **MUST use \`sverklo_search\` instead of Grep for any query that is conceptual or fuzzy** ("how does auth work", "anything related to billing", "where do we handle retries"). Grep is for exact strings only.
-- **MUST use \`sverklo_lookup\` to find a symbol's definition** by name — never grep + Read for this.
-- **MUST run \`sverklo_impact\` before renaming, deleting, or changing the signature of any function/class/method** that may be called from elsewhere. Report the blast radius (callers, depth) to the user before editing.
-- **MUST use \`sverklo_refs\` to enumerate callers of a symbol.**
-- **MUST use \`sverklo_deps\` to see imports + importers of a file** before moving or splitting it.
-- **MUST call \`sverklo_remember\` when the user corrects you** with phrasing like "stop X", "never X", "always Y", "don't Y", "prefer Z", "remember that I want Q", "actually, do W". Save with \`category:correction\` (stop/never/don't) or \`category:preference\` (prefer/want/like), \`kind:semantic\`, and the user's instruction as content. Save before continuing the response. Do not ask permission — corrections are explicit instructions to persist behavior across sessions.
-- **MUST call \`sverklo_recall\` at the start of work** on a non-trivial task to surface prior decisions and corrections.
+- **MUST call \`overview\` before exploring an unfamiliar directory.** It returns the PageRank-ranked map of the codebase in one call — much cheaper than \`ls\` + \`Read\` loops.
+- **MUST use \`search\` instead of Grep for any query that is conceptual or fuzzy** ("how does auth work", "anything related to billing", "where do we handle retries"). Grep is for exact strings only.
+- **MUST use \`lookup\` to find a symbol's definition** by name — never grep + Read for this.
+- **MUST run \`impact\` before renaming, deleting, or changing the signature of any function/class/method** that may be called from elsewhere. Report the blast radius (callers, depth) to the user before editing.
+- **MUST use \`refs\` to enumerate callers of a symbol.**
+- **MUST use \`deps\` to see imports + importers of a file** before moving or splitting it.
+- **MUST call \`remember\` when the user corrects you** with phrasing like "stop X", "never X", "always Y", "don't Y", "prefer Z", "remember that I want Q", "actually, do W". Save with \`category:correction\` (stop/never/don't) or \`category:preference\` (prefer/want/like), \`kind:semantic\`, and the user's instruction as content. Save before continuing the response. Do not ask permission — corrections are explicit instructions to persist behavior across sessions.
+- **MUST call \`recall\` at the start of work** on a non-trivial task to surface prior decisions and corrections.
 
 ### Never Do
 
-- **NEVER use Grep when the query is conceptual.** Grep cannot find "the auth flow" — sverklo_search can.
-- **NEVER edit a function or class without first running \`sverklo_impact\`** on it. Silently breaking a caller is the most expensive bug this codebase produces.
+- **NEVER use Grep when the query is conceptual.** Grep cannot find "the auth flow" — sverklo's \`search\` can.
+- **NEVER edit a function or class without first running \`impact\`** on it. Silently breaking a caller is the most expensive bug this codebase produces.
 - **NEVER ignore HIGH or CRITICAL impact warnings** without surfacing them to the user.
-- **NEVER rename symbols with find-and-replace.** Use \`sverklo_refs\` first; it knows which "foo" is the function and which is a string.
-- **NEVER save routine task summaries to memory.** \`sverklo_recall\` is only useful when hits are signal-dense — save only (a) bugs that took >1h to debug, (b) recurring mistakes, (c) non-obvious architectural decisions, (d) audit findings needing user judgment.
-- **NEVER re-read a file sverklo just returned a path for.** Use \`sverklo_lookup\` for the specific symbol instead.
+- **NEVER rename symbols with find-and-replace.** Use \`refs\` first; it knows which "foo" is the function and which is a string.
+- **NEVER save routine task summaries to memory.** \`recall\` is only useful when hits are signal-dense — save only (a) bugs that took >1h to debug, (b) recurring mistakes, (c) non-obvious architectural decisions, (d) audit findings needing user judgment.
+- **NEVER re-read a file sverklo just returned a path for.** Use \`lookup\` for the specific symbol instead.
 
 ### When Grep / Read still wins
 
@@ -48,7 +48,7 @@ This project has the sverklo MCP server installed. Sverklo is a code-intelligenc
 
 ### Exploration order
 
-\`sverklo_overview\` (1 call) → \`sverklo_search\` (1 call) → \`sverklo_lookup\` on the top hit → \`sverklo_refs\` / \`sverklo_impact\` only if you need the blast radius. If you've made 5 sverklo calls and still don't have the answer, **stop and ask a clarifying question** — don't burn 10 more.
+\`overview\` (1 call) → \`search\` (1 call) → \`lookup\` on the top hit → \`refs\` / \`impact\` only if you need the blast radius. If you've made 5 sverklo calls and still don't have the answer, **stop and ask a clarifying question** — don't burn 10 more.
 
 ### Output discipline
 
@@ -100,10 +100,15 @@ export type AgentsFileAction =
 
 /**
  * Secondary sentinel for Finding 7: detects the snippet's heading even
- * when the user hand-edited the body and removed the literal
- * "sverklo_search" sentinel. Without this, re-running `sverklo init`
- * would re-append the entire 30+ line snippet on top of the existing
- * (modified) one.
+ * when the user hand-edited the body and removed the literal sentinel.
+ *
+ * v0.28.0 (issue #71): the canonical tool names dropped the `sverklo_`
+ * prefix, so the new SVERKLO_SNIPPET body does not contain
+ * "sverklo_search" any more. The literal-sentinel string passed in below
+ * is kept as "sverklo_search" to detect PRE-v0.28 snippets that users
+ * already have in their AGENTS.md / CLAUDE.md — those still need to
+ * count as "snippet already present" so we don't double-inject. For
+ * fresh installs the heading regex is what catches the new snippet.
  */
 const HEADING_SENTINEL_RE = /^##\s+Sverklo\b/m;
 
@@ -364,7 +369,7 @@ function resolveSverkloBinary(): string {
 
 function buildAutoCaptureHook() {
   // PostToolUse hook — nudge Claude to capture decisions after Edit/Write tool calls.
-  // The hook output is visible to Claude, who decides whether to call sverklo_remember.
+  // The hook output is visible to Claude, who decides whether to call the `remember` tool.
   // Cheap, non-blocking, model-driven (no heuristic false positives).
   return {
     matcher: "Edit|Write|NotebookEdit",
@@ -372,7 +377,7 @@ function buildAutoCaptureHook() {
       {
         type: "command",
         command:
-          "echo 'If this edit represents a design decision, architectural choice, or pattern worth remembering, call sverklo_remember to save it. Skip if it is a routine fix.'",
+          "echo 'If this edit represents a design decision, architectural choice, or pattern worth remembering, call sverklo `remember` to save it. Skip if it is a routine fix.'",
         timeout: 3,
       },
     ],
@@ -691,8 +696,16 @@ export async function initProject(
     if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
 
     const existingPost = settings.hooks.PostToolUse as Array<{ hooks?: Array<{ command?: string }> }>;
+    // v0.28.0: the buildAutoCaptureHook command was rewritten to refer to
+    // `remember` instead of `sverklo_remember`. Detect either form so the
+    // hook stays idempotent across the rename: old installs continue to
+    // match the legacy literal; new installs match the marker phrase.
     const alreadyHasAutoCapture = existingPost.some((h) =>
-      h.hooks?.some((hook) => hook.command?.includes("sverklo_remember"))
+      h.hooks?.some(
+        (hook) =>
+          hook.command?.includes("sverklo_remember") ||
+          hook.command?.includes("call sverklo `remember`")
+      )
     );
 
     if (!alreadyHasAutoCapture) {

--- a/src/server/hints.ts
+++ b/src/server/hints.ts
@@ -50,40 +50,31 @@ export class HintEngine {
       names.some((n) => patterns.includes(n));
 
     // Diff workflow: any of the diff-aware tools were used recently
-    if (
-      hasAny("sverklo_review_diff", "sverklo_test_map", "sverklo_diff_search")
-    ) {
+    if (hasAny("review_diff", "test_map", "diff_search")) {
       return "reviewing-diff";
     }
 
     // Impact tracing: chained refs/impact lookups
     if (
-      last === "sverklo_impact" ||
-      last === "sverklo_refs" ||
-      (names.filter((n) => n === "sverklo_refs" || n === "sverklo_impact").length >= 2)
+      last === "impact" ||
+      last === "refs" ||
+      names.filter((n) => n === "refs" || n === "impact").length >= 2
     ) {
       return "tracing-impact";
     }
 
     // Memory curation: remember/recall/forget activity
-    if (
-      hasAny("sverklo_remember", "sverklo_forget", "sverklo_promote", "sverklo_demote")
-    ) {
+    if (hasAny("remember", "forget", "promote", "demote")) {
       return "memory-curating";
     }
 
     // Onboarding: overview followed by lookups/searches without a target
-    if (
-      names.includes("sverklo_overview") &&
-      names.length <= 4
-    ) {
+    if (names.includes("overview") && names.length <= 4) {
       return "onboarding";
     }
 
     // Debugging: search-heavy with error-shaped queries
-    const recentSearches = this.history.filter(
-      (c) => c.name === "sverklo_search"
-    );
+    const recentSearches = this.history.filter((c) => c.name === "search");
     if (recentSearches.length >= 2) {
       const queries = recentSearches
         .map((c) => String(c.args?.query ?? "").toLowerCase())
@@ -96,7 +87,7 @@ export class HintEngine {
       return "exploring";
     }
 
-    if (last === "sverklo_search" || last === "sverklo_lookup") {
+    if (last === "search" || last === "lookup") {
       return "exploring";
     }
 
@@ -128,81 +119,81 @@ export class HintEngine {
     const out: string[] = [];
 
     switch (tool) {
-      case "sverklo_review_diff": {
+      case "review_diff": {
         const ref = (args.ref as string) || "main..HEAD";
-        out.push(`Run \`sverklo_test_map ref:"${ref}"\` to see which changes lack tests.`);
-        out.push(`For any removed symbol with dangling refs, call \`sverklo_impact symbol:"<name>"\`.`);
+        out.push(`Run \`test_map ref:"${ref}"\` to see which changes lack tests.`);
+        out.push(`For any removed symbol with dangling refs, call \`impact symbol:"<name>"\`.`);
         break;
       }
-      case "sverklo_test_map": {
+      case "test_map": {
         const ref = (args.ref as string) || "main..HEAD";
-        if (!this.history.some((c) => c.name === "sverklo_review_diff")) {
-          out.push(`Pair this with \`sverklo_review_diff ref:"${ref}"\` for blast radius and risk scores.`);
+        if (!this.history.some((c) => c.name === "review_diff")) {
+          out.push(`Pair this with \`review_diff ref:"${ref}"\` for blast radius and risk scores.`);
         }
         out.push(`Untested high-risk files are the ones to push back on in review.`);
         break;
       }
-      case "sverklo_impact":
-      case "sverklo_refs": {
+      case "impact":
+      case "refs": {
         const sym = (args.symbol as string) || (args.name as string) || "<name>";
-        out.push(`Call \`sverklo_lookup symbol:"${sym}"\` to see the definition you're tracing.`);
+        out.push(`Call \`lookup symbol:"${sym}"\` to see the definition you're tracing.`);
         if (intent === "reviewing-diff") {
           out.push(`Each caller listed needs to be updated in the same diff if you removed the symbol.`);
         }
         break;
       }
-      case "sverklo_search": {
+      case "search": {
         if (intent === "debugging") {
-          out.push(`Narrow with \`sverklo_lookup\` if the search surfaced a likely target symbol.`);
-          out.push(`Call \`sverklo_recall query:"<error>"\` — there may be a saved memory about this issue.`);
+          out.push(`Narrow with \`lookup\` if the search surfaced a likely target symbol.`);
+          out.push(`Call \`recall query:"<error>"\` — there may be a saved memory about this issue.`);
         } else if (intent === "exploring") {
-          out.push(`If a symbol stands out, \`sverklo_refs symbol:"<name>"\` shows everything that uses it.`);
+          out.push(`If a symbol stands out, \`refs symbol:"<name>"\` shows everything that uses it.`);
         }
         break;
       }
-      case "sverklo_lookup": {
+      case "lookup": {
         const name = (args.name as string) || "<name>";
-        out.push(`\`sverklo_refs symbol:"${name}"\` enumerates everything that calls this.`);
-        out.push(`\`sverklo_deps file:"<file>"\` shows what the containing file imports.`);
+        out.push(`\`refs symbol:"${name}"\` enumerates everything that calls this.`);
+        out.push(`\`deps file:"<file>"\` shows what the containing file imports.`);
         break;
       }
-      case "sverklo_overview": {
-        out.push(`Try \`sverklo_recall query:"architecture"\` for any saved design decisions.`);
-        out.push(`Call \`sverklo_deps file:"<top-pagerank file>"\` on a high-PR file to see its centrality.`);
+      case "overview": {
+        out.push(`Try \`recall query:"architecture"\` for any saved design decisions.`);
+        out.push(`Call \`deps file:"<top-pagerank file>"\` on a high-PR file to see its centrality.`);
         break;
       }
-      case "sverklo_deps": {
-        out.push(`If a dependency looks suspicious, \`sverklo_search query:"<concept>"\` finds related code.`);
+      case "deps": {
+        out.push(`If a dependency looks suspicious, \`search query:"<concept>"\` finds related code.`);
         break;
       }
-      case "sverklo_recall": {
+      case "recall": {
         if (intent === "memory-curating") {
-          out.push(`Use \`sverklo_promote\` to mark a memory as core (always-loaded) context.`);
+          out.push(`Use \`promote\` to mark a memory as core (always-loaded) context.`);
         } else {
-          out.push(`If you act on a memory, \`sverklo_remember\` the outcome so the next session starts smarter.`);
+          out.push(`If you act on a memory, \`remember\` the outcome so the next session starts smarter.`);
         }
         break;
       }
-      case "sverklo_remember": {
-        out.push(`\`sverklo_promote id:<id>\` to make this a core memory loaded on every session.`);
+      case "remember": {
+        out.push(`\`promote id:<id>\` to make this a core memory loaded on every session.`);
         break;
       }
-      case "sverklo_context": {
+      case "context": {
         const task = (args.task as string) || "";
         const detail = (args.detail_level as string) || "normal";
         if (detail !== "full") {
           out.push(`If the bundle isn't enough, re-run with \`detail_level:"full"\` for dependency neighbours.`);
         }
-        out.push(`Drill into a specific symbol with \`sverklo_lookup\` or \`sverklo_refs\` from the relevant-code list.`);
+        out.push(`Drill into a specific symbol with \`lookup\` or \`refs\` from the relevant-code list.`);
         if (/bug|error|fail|broken/i.test(task)) {
-          out.push(`Looks like a debug task — \`sverklo_recall query:"${task.slice(0, 60)}"\` may surface a known issue.`);
+          out.push(`Looks like a debug task — \`recall query:"${task.slice(0, 60)}"\` may surface a known issue.`);
         }
         break;
       }
-      case "sverklo_diff_search": {
+      case "diff_search": {
         const ref = (args.ref as string) || "main..HEAD";
-        if (!this.history.some((c) => c.name === "sverklo_review_diff")) {
-          out.push(`Run \`sverklo_review_diff ref:"${ref}"\` first for the structural picture.`);
+        if (!this.history.some((c) => c.name === "review_diff")) {
+          out.push(`Run \`review_diff ref:"${ref}"\` first for the structural picture.`);
         }
         break;
       }

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -86,6 +86,99 @@ import { logActivity } from "../utils/activity-log.js";
 import { ToolStatsWriter } from "../utils/tool-stats.js";
 import { pinTool, unpinTool, handlePin, handleUnpin } from "./tools/pin.js";
 
+// ── v0.28.0 tool rename: deprecation aliases (issue #71) ─────────────
+//
+// In v0.28.0 we dropped the redundant `sverklo_` prefix from every tool's
+// canonical name. MCP clients (Claude Code, opencode, Cursor) already
+// namespace tools by server name, so the old `sverklo_search` showed up as
+// `mcp__sverklo__sverklo_search` — double-prefix noise in every tool ID.
+//
+// To avoid breaking everyone's pinned skills/docs on day one, we keep the
+// legacy `sverklo_*` names alive as routing aliases for one minor release.
+// On the FIRST invocation of each legacy name per server instance, we emit
+// a one-time stderr warning. v0.29.0 will remove the aliases.
+//
+// Tools are advertised in `tools/list` under their CANONICAL names only —
+// we don't dual-advertise to keep the tool count stable (37, not 74). The
+// alias map drives both deprecation warnings and switch-case dispatch.
+export const LEGACY_TOOL_ALIASES: Record<string, string> = {
+  sverklo_context: "context",
+  sverklo_search: "search",
+  sverklo_overview: "overview",
+  sverklo_lookup: "lookup",
+  sverklo_refs: "refs",
+  sverklo_deps: "deps",
+  sverklo_status: "status",
+  sverklo_remember: "remember",
+  sverklo_recall: "recall",
+  sverklo_forget: "forget",
+  sverklo_memories: "memories",
+  sverklo_ast_grep: "ast_grep",
+  sverklo_impact: "impact",
+  sverklo_audit: "audit",
+  sverklo_wakeup: "wakeup",
+  sverklo_review_diff: "review_diff",
+  sverklo_diff_search: "diff_search",
+  sverklo_test_map: "test_map",
+  sverklo_promote: "promote",
+  sverklo_demote: "demote",
+  sverklo_clusters: "clusters",
+  sverklo_pin: "pin",
+  sverklo_unpin: "unpin",
+  sverklo_investigate: "investigate",
+  sverklo_search_iterative: "search_iterative",
+  sverklo_ask: "ask",
+  sverklo_verify: "verify",
+  sverklo_critique: "critique",
+  sverklo_concepts: "concepts",
+  sverklo_patterns: "patterns",
+  sverklo_grep_results: "grep_results",
+  sverklo_head_results: "head_results",
+  sverklo_ctx_peek: "ctx_peek",
+  sverklo_ctx_slice: "ctx_slice",
+  sverklo_ctx_grep: "ctx_grep",
+  sverklo_ctx_stats: "ctx_stats",
+  sverklo_list_repos: "list_repos",
+};
+
+// Zilliz claude-context compatibility names — these are not first-party
+// sverklo tools and are excluded from telemetry / trajectory recording.
+const COMPAT_ALIASES = new Set<string>([
+  "index_codebase",
+  "search_code",
+  "clear_index",
+  "get_indexing_status",
+]);
+
+function isCompatAlias(name: string): boolean {
+  return COMPAT_ALIASES.has(name);
+}
+
+/**
+ * Resolve a possibly-legacy tool name to its canonical form, emitting a
+ * one-time stderr deprecation warning the first time each legacy name is
+ * seen in this server instance. Pure function on the resolution side;
+ * mutates `warnedAliases` as a side effect. Returns the canonical name.
+ *
+ * Exported for unit tests.
+ */
+export function resolveToolName(
+  name: string,
+  warnedAliases: Set<string>,
+  writeWarning: (msg: string) => void = (m) => process.stderr.write(m)
+): string {
+  const canonical = LEGACY_TOOL_ALIASES[name];
+  if (!canonical) return name;
+  if (!warnedAliases.has(name)) {
+    warnedAliases.add(name);
+    writeWarning(
+      `[sverklo:DEPRECATED] tool name "${name}" is deprecated; use "${canonical}". ` +
+        `The old name will be removed in v0.29.0.\n`
+    );
+  }
+  return canonical;
+}
+
 // Zilliz claude-context compatibility tool definitions.
 // These mirror github.com/zilliztech/claude-context tool names so users can
 // swap claude-context for sverklo without changing their MCP client config.
@@ -113,9 +206,9 @@ const indexCodebaseTool = {
 const searchCodeTool = {
   name: "search_code",
   description:
-    "[Zilliz claude-context compat] Alias for sverklo_search. Semantic + text hybrid " +
-    "code search using embeddings and PageRank. Provided for drop-in compatibility " +
-    "with the Zilliz claude-context MCP server.",
+    "[Zilliz claude-context compat] Alias for sverklo's `search` tool. Semantic + " +
+    "text hybrid code search using embeddings and PageRank. Provided for drop-in " +
+    "compatibility with the Zilliz claude-context MCP server.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -143,8 +236,9 @@ const clearIndexTool = {
 const getIndexingStatusTool = {
   name: "get_indexing_status",
   description:
-    "[Zilliz claude-context compat] Alias for sverklo_status. Returns current indexing " +
-    "progress and statistics. Provided for drop-in compatibility with Zilliz claude-context.",
+    "[Zilliz claude-context compat] Alias for sverklo's `status` tool. Returns " +
+    "current indexing progress and statistics. Provided for drop-in compatibility " +
+    "with Zilliz claude-context.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -274,8 +368,8 @@ export async function startMcpServer(rootPath: string): Promise<void> {
       parts.push(`${status.fileCount} files, ${status.chunkCount} chunks indexed`);
       parts.push(`Languages: ${status.languages.join(", ") || "none"}`);
       parts.push("");
-      parts.push("Use sverklo_search for semantic code search (preferred over grep).");
-      parts.push("Use sverklo_remember to save important decisions.");
+      parts.push("Use the sverklo `search` tool for semantic code search (preferred over grep).");
+      parts.push("Use the sverklo `remember` tool to save important decisions.");
 
       return {
         contents: [
@@ -375,14 +469,23 @@ export async function startMcpServer(rootPath: string): Promise<void> {
     tools: visibleTools,
   }));
 
+  // Tracks which legacy tool names have already emitted their one-time
+  // deprecation warning in this server instance. v0.28.0 → v0.29.0 sunset.
+  const warnedAliases = new Set<string>();
+
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params;
+    const rawName = request.params.name;
+    const args = request.params.arguments;
+    // Rewrite legacy `sverklo_*` names to canonical short form. Emits a
+    // one-time stderr warning per legacy name. Pass-through for canonical
+    // and compat-alias names.
+    const name = resolveToolName(rawName, warnedAliases);
 
     // Ensure index is ready for search operations.
     // Status tools and clear_index don't need to wait — they manage indexing themselves.
     const skipWait =
-      name === "sverklo_status" ||
+      name === "status" ||
       name === "get_indexing_status" ||
       name === "clear_index" ||
       name === "index_codebase";
@@ -401,112 +504,112 @@ export async function startMcpServer(rootPath: string): Promise<void> {
       let result: string;
 
       switch (name) {
-        case "sverklo_context":
+        case "context":
           result = await handleContext(indexer, args || {});
           break;
-        case "sverklo_search":
+        case "search":
           result = await handleSearch(indexer, args || {});
           break;
-        case "sverklo_overview":
+        case "overview":
           result = handleOverview(indexer, args || {});
           break;
-        case "sverklo_lookup":
+        case "lookup":
           result = await handleLookup(indexer, args || {});
           break;
-        case "sverklo_refs":
+        case "refs":
           result = await handleFindReferences(indexer, args || {});
           break;
-        case "sverklo_deps":
+        case "deps":
           result = handleDependencies(indexer, args || {});
           break;
-        case "sverklo_status":
+        case "status":
           result = handleIndexStatus(indexer);
           break;
-        case "sverklo_remember":
+        case "remember":
           result = await handleRemember(indexer, args || {});
           break;
-        case "sverklo_recall":
+        case "recall":
           result = await handleRecall(indexer, args || {});
           break;
-        case "sverklo_forget":
+        case "forget":
           result = handleForget(indexer, args || {});
           break;
-        case "sverklo_memories":
+        case "memories":
           result = handleMemories(indexer, args || {});
           break;
-        case "sverklo_ast_grep":
+        case "ast_grep":
           result = handleAstGrep(indexer, args || {});
           break;
-        case "sverklo_impact":
+        case "impact":
           result = handleImpact(indexer, args || {});
           break;
-        case "sverklo_audit":
+        case "audit":
           result = handleAudit(indexer, args || {});
           break;
-        case "sverklo_wakeup":
+        case "wakeup":
           result = handleWakeup(indexer, args || {});
           break;
-        case "sverklo_review_diff":
+        case "review_diff":
           result = handleReviewDiff(indexer, args || {});
           break;
-        case "sverklo_diff_search":
+        case "diff_search":
           result = await handleDiffSearch(indexer, args || {});
           break;
-        case "sverklo_test_map":
+        case "test_map":
           result = handleTestMap(indexer, args || {});
           break;
-        case "sverklo_promote":
+        case "promote":
           result = handlePromote(indexer, args || {});
           break;
-        case "sverklo_demote":
+        case "demote":
           result = handleDemote(indexer, args || {});
           break;
-        case "sverklo_clusters":
+        case "clusters":
           result = handleClusters(indexer, args || {});
           break;
-        case "sverklo_pin":
+        case "pin":
           result = handlePin(indexer, args || {});
           break;
-        case "sverklo_unpin":
+        case "unpin":
           result = handleUnpin(indexer, args || {});
           break;
-        case "sverklo_investigate":
+        case "investigate":
           result = await handleInvestigate(indexer, args || {});
           break;
-        case "sverklo_search_iterative":
+        case "search_iterative":
           result = await handleSearchIterative(indexer, args || {});
           break;
-        case "sverklo_ask":
+        case "ask":
           result = await handleAsk(indexer, args || {});
           break;
-        case "sverklo_verify":
+        case "verify":
           result = handleVerify(indexer, args || {});
           break;
-        case "sverklo_critique":
+        case "critique":
           result = handleCritique(indexer, args || {});
           break;
-        case "sverklo_concepts":
+        case "concepts":
           result = await handleConcepts(indexer, args || {});
           break;
-        case "sverklo_patterns":
+        case "patterns":
           result = handlePatterns(indexer, args || {});
           break;
-        case "sverklo_grep_results":
+        case "grep_results":
           result = handleGrepResults(args || {});
           break;
-        case "sverklo_head_results":
+        case "head_results":
           result = handleHeadResults(args || {});
           break;
-        case "sverklo_ctx_peek":
+        case "ctx_peek":
           result = handleCtxPeek(args || {});
           break;
-        case "sverklo_ctx_slice":
+        case "ctx_slice":
           result = handleCtxSlice(indexer, args || {});
           break;
-        case "sverklo_ctx_grep":
+        case "ctx_grep":
           result = handleCtxGrep(indexer, args || {});
           break;
-        case "sverklo_ctx_stats":
+        case "ctx_stats":
           result = handleCtxStats(indexer, args || {});
           break;
 
@@ -587,16 +690,16 @@ export async function startMcpServer(rootPath: string): Promise<void> {
       // second retrieval. Tools that don't return result blocks (status,
       // memories, verify, etc.) don't register — their output isn't blockish.
       if (
-        name === "sverklo_search" ||
-        name === "sverklo_refs" ||
-        name === "sverklo_lookup" ||
-        name === "sverklo_impact" ||
-        name === "sverklo_diff_search" ||
-        name === "sverklo_ast_grep" ||
-        name === "sverklo_investigate" ||
-        name === "sverklo_search_iterative" ||
-        name === "sverklo_context" ||
-        name === "sverklo_ask"
+        name === "search" ||
+        name === "refs" ||
+        name === "lookup" ||
+        name === "impact" ||
+        name === "diff_search" ||
+        name === "ast_grep" ||
+        name === "investigate" ||
+        name === "search_iterative" ||
+        name === "context" ||
+        name === "ask"
       ) {
         const id = responseStore.set(name, result);
         // Persistent handle (P1-8) — survives across MCP sessions.
@@ -606,11 +709,12 @@ export async function startMcpServer(rootPath: string): Promise<void> {
         result = result + `\n\n_response_id: ${id} · handle: ${uri}_`;
       }
 
-      // Fire-and-forget telemetry. Only sverklo_* names are tracked
+      // Fire-and-forget telemetry. Only first-party tool names are tracked
       // (compat aliases like search_code are excluded — they pollute the
       // tool name distribution and we already account for them via the
-      // underlying handlers).
-      if (name.startsWith("sverklo_")) {
+      // underlying handlers). v0.28.0 renamed the canonical names — anything
+      // NOT one of the four Zilliz compat names is one of ours.
+      if (!isCompatAlias(name)) {
         const dur = Date.now() - __telemetryStart;
         // Bucketed response size — lets us answer "did flipping `compact`
         // default actually save tokens?" without recording any content.
@@ -656,7 +760,7 @@ export async function startMcpServer(rootPath: string): Promise<void> {
         outcome: "error",
         errorCode: err instanceof Error && err.name !== "Error" ? err.name : undefined,
       });
-      if (name.startsWith("sverklo_")) {
+      if (!isCompatAlias(name)) {
         void track("tool.call", {
           tool: name,
           outcome: "error",
@@ -695,7 +799,7 @@ export async function startMcpServer(rootPath: string): Promise<void> {
 const repoProperty = {
   type: "string" as const,
   description:
-    "Repository name (from sverklo_list_repos). " +
+    "Repository name (from the list_repos tool). " +
     "Optional if only one repo is indexed.",
 };
 
@@ -746,7 +850,7 @@ export async function startGlobalMcpServer(): Promise<void> {
       },
       instructions:
         "Sverklo (global mode): code intelligence serving multiple repos. " +
-        "Use sverklo_list_repos to see available repositories, then pass the " +
+        "Use the list_repos tool to see available repositories, then pass the " +
         "repo name to any tool. If only one repo is registered, the repo " +
         "parameter is optional.",
     }
@@ -766,7 +870,7 @@ export async function startGlobalMcpServer(): Promise<void> {
     name: p.name,
     description: p.description,
     arguments: [
-      { name: "repo", description: "Repository name (from sverklo_list_repos). Optional if only one repo is indexed.", required: false },
+      { name: "repo", description: "Repository name (from the list_repos tool). Optional if only one repo is indexed.", required: false },
       ...p.arguments,
     ],
   }));
@@ -852,12 +956,18 @@ export async function startGlobalMcpServer(): Promise<void> {
     tools: visibleTools,
   }));
 
+  // Tracks which legacy tool names have already emitted their one-time
+  // deprecation warning in this server instance. v0.28.0 → v0.29.0 sunset.
+  const warnedAliases = new Set<string>();
+
   // Handle tool calls — resolve indexer from pool based on `repo` arg
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params;
+    const rawName = request.params.name;
+    const args = request.params.arguments;
+    const name = resolveToolName(rawName, warnedAliases);
 
     // list_repos doesn't need an indexer
-    if (name === "sverklo_list_repos") {
+    if (name === "list_repos") {
       const result = handleListRepos();
       if (process.env.SVERKLO_DISABLE_HINTS !== "1") {
         const argRecord = (args || {}) as Record<string, unknown>;
@@ -878,12 +988,12 @@ export async function startGlobalMcpServer(): Promise<void> {
     // pool throws "No repositories registered..." which the MCP catch
     // below converts to `isError: true`. Clients like OpenCode render
     // that as a generic "Not connected", hiding the actionable
-    // remediation message. For sverklo_status and sverklo_list_repos
-    // specifically, the "no repos" state is NOT an error — it's the
-    // expected first-run state. Return the registration hint as a
-    // normal text response so the agent surfaces it.
+    // remediation message. For status and list_repos specifically, the
+    // "no repos" state is NOT an error — it's the expected first-run
+    // state. Return the registration hint as a normal text response so
+    // the agent surfaces it.
     if (
-      (name === "sverklo_status" || name === "sverklo_list_repos" || name === "get_indexing_status") &&
+      (name === "status" || name === "list_repos" || name === "get_indexing_status") &&
       Object.keys(getRegistry()).length === 0
     ) {
       void track("tool.call", { tool: name, outcome: "ok", duration_ms: 0 });
@@ -897,7 +1007,7 @@ export async function startGlobalMcpServer(): Promise<void> {
         "# or from anywhere\n" +
         `sverklo register ${cwd}\n` +
         "```\n\n" +
-        "Then call `sverklo_status` again to see the index. " +
+        "Then call `status` again to see the index. " +
         "The MCP server picks up new registrations without a restart.";
       return { content: [{ type: "text" as const, text: hintText }] };
     }
@@ -907,7 +1017,7 @@ export async function startGlobalMcpServer(): Promise<void> {
 
       // Wait for index on search-like operations
       const skipWait =
-        name === "sverklo_status" ||
+        name === "status" ||
         name === "get_indexing_status" ||
         name === "clear_index" ||
         name === "index_codebase";
@@ -918,112 +1028,112 @@ export async function startGlobalMcpServer(): Promise<void> {
       let result: string;
 
       switch (name) {
-        case "sverklo_context":
+        case "context":
           result = await handleContext(indexer, args || {});
           break;
-        case "sverklo_search":
+        case "search":
           result = await handleSearch(indexer, args || {});
           break;
-        case "sverklo_overview":
+        case "overview":
           result = handleOverview(indexer, args || {});
           break;
-        case "sverklo_lookup":
+        case "lookup":
           result = await handleLookup(indexer, args || {});
           break;
-        case "sverklo_refs":
+        case "refs":
           result = await handleFindReferences(indexer, args || {});
           break;
-        case "sverklo_deps":
+        case "deps":
           result = handleDependencies(indexer, args || {});
           break;
-        case "sverklo_status":
+        case "status":
           result = handleIndexStatus(indexer);
           break;
-        case "sverklo_remember":
+        case "remember":
           result = await handleRemember(indexer, args || {});
           break;
-        case "sverklo_recall":
+        case "recall":
           result = await handleRecall(indexer, args || {});
           break;
-        case "sverklo_forget":
+        case "forget":
           result = handleForget(indexer, args || {});
           break;
-        case "sverklo_memories":
+        case "memories":
           result = handleMemories(indexer, args || {});
           break;
-        case "sverklo_ast_grep":
+        case "ast_grep":
           result = handleAstGrep(indexer, args || {});
           break;
-        case "sverklo_impact":
+        case "impact":
           result = handleImpact(indexer, args || {});
           break;
-        case "sverklo_audit":
+        case "audit":
           result = handleAudit(indexer, args || {});
           break;
-        case "sverklo_wakeup":
+        case "wakeup":
           result = handleWakeup(indexer, args || {});
           break;
-        case "sverklo_review_diff":
+        case "review_diff":
           result = handleReviewDiff(indexer, args || {});
           break;
-        case "sverklo_diff_search":
+        case "diff_search":
           result = await handleDiffSearch(indexer, args || {});
           break;
-        case "sverklo_test_map":
+        case "test_map":
           result = handleTestMap(indexer, args || {});
           break;
-        case "sverklo_promote":
+        case "promote":
           result = handlePromote(indexer, args || {});
           break;
-        case "sverklo_demote":
+        case "demote":
           result = handleDemote(indexer, args || {});
           break;
-        case "sverklo_clusters":
+        case "clusters":
           result = handleClusters(indexer, args || {});
           break;
-        case "sverklo_pin":
+        case "pin":
           result = handlePin(indexer, args || {});
           break;
-        case "sverklo_unpin":
+        case "unpin":
           result = handleUnpin(indexer, args || {});
           break;
-        case "sverklo_investigate":
+        case "investigate":
           result = await handleInvestigate(indexer, args || {});
           break;
-        case "sverklo_search_iterative":
+        case "search_iterative":
           result = await handleSearchIterative(indexer, args || {});
           break;
-        case "sverklo_ask":
+        case "ask":
           result = await handleAsk(indexer, args || {});
           break;
-        case "sverklo_verify":
+        case "verify":
           result = handleVerify(indexer, args || {});
           break;
-        case "sverklo_critique":
+        case "critique":
           result = handleCritique(indexer, args || {});
           break;
-        case "sverklo_concepts":
+        case "concepts":
           result = await handleConcepts(indexer, args || {});
           break;
-        case "sverklo_patterns":
+        case "patterns":
           result = handlePatterns(indexer, args || {});
           break;
-        case "sverklo_grep_results":
+        case "grep_results":
           result = handleGrepResults(args || {});
           break;
-        case "sverklo_head_results":
+        case "head_results":
           result = handleHeadResults(args || {});
           break;
-        case "sverklo_ctx_peek":
+        case "ctx_peek":
           result = handleCtxPeek(args || {});
           break;
-        case "sverklo_ctx_slice":
+        case "ctx_slice":
           result = handleCtxSlice(indexer, args || {});
           break;
-        case "sverklo_ctx_grep":
+        case "ctx_grep":
           result = handleCtxGrep(indexer, args || {});
           break;
-        case "sverklo_ctx_stats":
+        case "ctx_stats":
           result = handleCtxStats(indexer, args || {});
           break;
 
@@ -1094,16 +1204,16 @@ export async function startGlobalMcpServer(): Promise<void> {
       }
 
       if (
-        name === "sverklo_search" ||
-        name === "sverklo_refs" ||
-        name === "sverklo_lookup" ||
-        name === "sverklo_impact" ||
-        name === "sverklo_diff_search" ||
-        name === "sverklo_ast_grep" ||
-        name === "sverklo_investigate" ||
-        name === "sverklo_search_iterative" ||
-        name === "sverklo_context" ||
-        name === "sverklo_ask"
+        name === "search" ||
+        name === "refs" ||
+        name === "lookup" ||
+        name === "impact" ||
+        name === "diff_search" ||
+        name === "ast_grep" ||
+        name === "investigate" ||
+        name === "search_iterative" ||
+        name === "context" ||
+        name === "ask"
       ) {
         const id = responseStore.set(name, result);
         // Persistent handle (P1-8) — survives across MCP sessions.
@@ -1113,7 +1223,7 @@ export async function startGlobalMcpServer(): Promise<void> {
         result = result + `\n\n_response_id: ${id} · handle: ${uri}_`;
       }
 
-      if (name.startsWith("sverklo_")) {
+      if (!isCompatAlias(name)) {
         const dur = Date.now() - __telemetryStart;
         // Bucketed response size — lets us answer "did flipping `compact`
         // default actually save tokens?" without recording any content.
@@ -1149,7 +1259,7 @@ export async function startGlobalMcpServer(): Promise<void> {
         "tool.error",
         { tool: name, error: err instanceof Error ? err.message : String(err) }
       );
-      if (name.startsWith("sverklo_")) {
+      if (!isCompatAlias(name)) {
         void track("tool.call", {
           tool: name,
           outcome: "error",

--- a/src/server/prompts.ts
+++ b/src/server/prompts.ts
@@ -39,10 +39,10 @@ const REVIEW_CHANGES: PromptDefinition = {
     const r = ref || "main..HEAD";
     return `You are reviewing the diff \`${r}\`. Use sverklo's diff-aware tools, in order:
 
-1. Call \`sverklo_review_diff\` with \`ref:"${r}"\` to get the changed files, semantic delta (added/removed/modified symbols), dangling references for removed symbols, importer counts, and a per-file risk score. Read the **Highest-risk files** section first.
-2. Call \`sverklo_test_map\` with \`ref:"${r}"\` to see which tests cover the changes and which changed files have no matching tests. Prioritise the risk-ranked uncovered list.
-3. For any removed symbol with dangling references, call \`sverklo_impact symbol:"<name>"\` to enumerate every caller — these are likely breakages.
-4. For any added symbol that looks like it duplicates existing functionality, call \`sverklo_lookup\` to find the existing definition.
+1. Call \`review_diff\` with \`ref:"${r}"\` to get the changed files, semantic delta (added/removed/modified symbols), dangling references for removed symbols, importer counts, and a per-file risk score. Read the **Highest-risk files** section first.
+2. Call \`test_map\` with \`ref:"${r}"\` to see which tests cover the changes and which changed files have no matching tests. Prioritise the risk-ranked uncovered list.
+3. For any removed symbol with dangling references, call \`impact symbol:"<name>"\` to enumerate every caller — these are likely breakages.
+4. For any added symbol that looks like it duplicates existing functionality, call \`lookup\` to find the existing definition.
 5. Only after the above, read the actual diff with \`git diff ${r}\` for the highest-risk file(s).
 
 Constraint: keep the total number of tool calls under 8. Do not grep for things sverklo can answer structurally. Do not paraphrase the tool output back at the user — synthesise the review. End with a clear verdict (LGTM / request changes / blocking concern) and a bulleted list of must-fix items, each tied to a file:line.`;
@@ -64,16 +64,16 @@ const PRE_MERGE_CHECK: PromptDefinition = {
     const r = ref || "main..HEAD";
     return `You are the last reviewer before merging \`${r}\`. Be strict.
 
-1. Call \`sverklo_review_diff ref:"${r}"\`. The response includes a per-file risk score. **Block the merge** if any file is risk level "critical" without an explicit reason in the PR description.
-2. Call \`sverklo_test_map ref:"${r}"\`. **Block the merge** if any uncovered file has risk level "high" or "critical" — require tests or an explicit waiver.
-3. For every removed symbol with dangling references, call \`sverklo_impact\` and verify each caller has been updated in the same diff. A dangling reference is a hard block.
-4. Call \`sverklo_recall query:"<area being changed>"\` to surface any prior decisions or invariants that this change might violate.
+1. Call \`review_diff ref:"${r}"\`. The response includes a per-file risk score. **Block the merge** if any file is risk level "critical" without an explicit reason in the PR description.
+2. Call \`test_map ref:"${r}"\`. **Block the merge** if any uncovered file has risk level "high" or "critical" — require tests or an explicit waiver.
+3. For every removed symbol with dangling references, call \`impact\` and verify each caller has been updated in the same diff. A dangling reference is a hard block.
+4. Call \`recall query:"<area being changed>"\` to surface any prior decisions or invariants that this change might violate.
 
 Output a structured verdict:
 - **Status:** APPROVED / BLOCKED / NEEDS CLARIFICATION
 - **Blocking issues:** (file:line + reason)
 - **Non-blocking concerns:** (file:line + reason)
-- **Suggested follow-ups:** (memories to save with sverklo_remember, or tests to add)
+- **Suggested follow-ups:** (memories to save with remember, or tests to add)
 
 Do not approve without justification for every "high" or "critical" risk file.`;
   },
@@ -82,7 +82,7 @@ Do not approve without justification for every "high" or "critical" risk file.`;
 const ONBOARD: PromptDefinition = {
   name: "sverklo/onboard",
   description:
-    "New-developer onboarding tour. Builds a mental model of the codebase using sverklo_overview, top-PageRank files, and core memories.",
+    "New-developer onboarding tour. Builds a mental model of the codebase using overview, top-PageRank files, and core memories.",
   arguments: [
     {
       name: "focus",
@@ -96,10 +96,10 @@ const ONBOARD: PromptDefinition = {
       : "Give a generalist tour suitable for any new contributor.";
     return `Help a new developer get oriented in this codebase. ${focusLine}
 
-1. Call \`sverklo_overview\` to get the high-level structure: top languages, top-PageRank files, module map.
-2. Call \`sverklo_recall query:"architecture"\` and \`sverklo_recall query:"conventions"\` to surface any saved invariants and design decisions.
-3. ${focus ? `Call \`sverklo_search query:"${focus}"\` to find the entry points for the focus area.` : "Pick 2-3 of the highest-PageRank source files and call `sverklo_lookup` on their main exported symbols to show what they do."}
-4. For the most central file you find, call \`sverklo_deps\` to show its place in the import graph.
+1. Call \`overview\` to get the high-level structure: top languages, top-PageRank files, module map.
+2. Call \`recall query:"architecture"\` and \`recall query:"conventions"\` to surface any saved invariants and design decisions.
+3. ${focus ? `Call \`search query:"${focus}"\` to find the entry points for the focus area.` : "Pick 2-3 of the highest-PageRank source files and call `lookup` on their main exported symbols to show what they do."}
+4. For the most central file you find, call \`deps\` to show its place in the import graph.
 
 Then write a concise onboarding doc (under 600 words) with:
 - "Start here" — the 3-5 files to read first, in order, with a one-line reason for each
@@ -118,10 +118,10 @@ const ARCHITECTURE_MAP: PromptDefinition = {
   arguments: [],
   build: () => `Produce an architecture map of this codebase using only sverklo tools.
 
-1. Call \`sverklo_overview\` for the structural summary (file/chunk/language counts, top-PageRank files).
-2. For each of the top 5 PageRank files, call \`sverklo_deps\` to see what depends on it and what it depends on. These are the load-bearing modules.
-3. Call \`sverklo_recall query:"architecture"\` for any saved design decisions.
-4. Call \`sverklo_search query:"entry point main bootstrap"\` to find the application entry points.
+1. Call \`overview\` for the structural summary (file/chunk/language counts, top-PageRank files).
+2. For each of the top 5 PageRank files, call \`deps\` to see what depends on it and what it depends on. These are the load-bearing modules.
+3. Call \`recall query:"architecture"\` for any saved design decisions.
+4. Call \`search query:"entry point main bootstrap"\` to find the application entry points.
 
 Produce an architecture map with:
 - **Entry points** — where execution starts
@@ -147,11 +147,11 @@ const DEBUG_ISSUE: PromptDefinition = {
   build: ({ symptom }) => {
     return `Help debug this issue: **${symptom || "(unspecified — ask the user for the symptom first)"}**
 
-1. Call \`sverklo_recall query:"${symptom}"\` — there may be a prior decision or known-issue memory that explains this.
-2. Call \`sverklo_search query:"${symptom}"\` to find the most semantically relevant code regions. Read the top 3 results.
-3. From those results, identify the 1-2 most likely entry points or error sources. Call \`sverklo_refs symbol:"<name>"\` on each to see who calls them — the bug may be in a caller, not the function itself.
-4. If the symptom mentions a specific error message, call \`sverklo_search query:"<error string>"\` to find where it's thrown.
-5. Call \`sverklo_deps file:"<suspect file>"\` to see what the suspect code depends on — the bug may be in a dependency.
+1. Call \`recall query:"${symptom}"\` — there may be a prior decision or known-issue memory that explains this.
+2. Call \`search query:"${symptom}"\` to find the most semantically relevant code regions. Read the top 3 results.
+3. From those results, identify the 1-2 most likely entry points or error sources. Call \`refs symbol:"<name>"\` on each to see who calls them — the bug may be in a caller, not the function itself.
+4. If the symptom mentions a specific error message, call \`search query:"<error string>"\` to find where it's thrown.
+5. Call \`deps file:"<suspect file>"\` to see what the suspect code depends on — the bug may be in a dependency.
 
 Then produce:
 - **Most likely root cause:** (file:line + one-paragraph explanation)
@@ -163,14 +163,14 @@ Do not propose code changes without identifying a specific file:line. If the sea
   },
 };
 
-// ── Research recipes (v0.14, P1-16). Leverage sverklo_investigate +
-// sverklo_verify so answers stay grounded in evidence the user can audit.
+// ── Research recipes (v0.14, P1-16). Leverage investigate +
+// verify so answers stay grounded in evidence the user can audit.
 
 const MAP_FEATURE: PromptDefinition = {
   name: "sverklo/map-feature",
   description:
     "Map a feature across the codebase: entry points, key symbols, tests, and docs. " +
-    "Uses sverklo_investigate to fan-out over FTS + vector + symbol + refs in one call.",
+    "Uses investigate to fan-out over FTS + vector + symbol + refs in one call.",
   arguments: [
     {
       name: "feature",
@@ -188,10 +188,10 @@ const MAP_FEATURE: PromptDefinition = {
     const scopeArg = scope ? `, scope:"${scope}"` : "";
     return `Map the \`${feature}\` feature across the codebase. Use sverklo's research tools in this order:
 
-1. Call \`sverklo_investigate query:"${feature}"${scopeArg}\` for a single-pass fan-out over FTS, embeddings, symbols, and refs. Read the \`found_by\` tags — results agreed on by multiple retrievers are higher-signal than single-source hits.
-2. Pick the top 3-5 symbols from the investigation and call \`sverklo_refs\` on each to expand the surface area. Note any **Doc mentions** sections — they tell you where the feature is documented.
-3. For the two most-referenced symbols, call \`sverklo_impact\` to see blast radius before proposing any changes. If partition plans appear, pick one bucket and drill in rather than reading the full list.
-4. Call \`sverklo_test_map\` scoped to the same directories — which tests cover this feature?
+1. Call \`investigate query:"${feature}"${scopeArg}\` for a single-pass fan-out over FTS, embeddings, symbols, and refs. Read the \`found_by\` tags — results agreed on by multiple retrievers are higher-signal than single-source hits.
+2. Pick the top 3-5 symbols from the investigation and call \`refs\` on each to expand the surface area. Note any **Doc mentions** sections — they tell you where the feature is documented.
+3. For the two most-referenced symbols, call \`impact\` to see blast radius before proposing any changes. If partition plans appear, pick one bucket and drill in rather than reading the full list.
+4. Call \`test_map\` scoped to the same directories — which tests cover this feature?
 5. Summarise in this structure:
    - **Entry points:** 1-3 files where the feature is first reached
    - **Core symbols:** classes/functions that implement it
@@ -200,7 +200,7 @@ const MAP_FEATURE: PromptDefinition = {
    - **Docs:** README / ADR sections that describe it
    - **Open questions:** things sverklo's retrievers couldn't pin down
 
-End with a list of evidence ids (from the \`evidence\` footers) the user can \`sverklo_verify\` if they want to audit your map.`;
+End with a list of evidence ids (from the \`evidence\` footers) the user can \`verify\` if they want to audit your map.`;
   },
 };
 
@@ -224,11 +224,11 @@ const ASSESS_IMPACT: PromptDefinition = {
     return `Assess the impact of changing \`${symbol}\`.${changeLine}
 Run these steps, in order:
 
-1. \`sverklo_lookup symbol:"${symbol}"\` — confirm exactly one definition exists. If there are multiple, pin down which one the change targets before proceeding.
-2. \`sverklo_impact symbol:"${symbol}"\` — full caller graph. If the result returns a partition plan (> 80 callers), traverse one bucket at a time rather than reading the raw list.
-3. \`sverklo_test_map symbol:"${symbol}"\` — which tests exercise the callers? Callers with zero test coverage are the highest-risk items.
-4. \`sverklo_refs symbol:"${symbol}"\` with \`exact:true\` — confirms we haven't missed documentation mentions. If any **Doc mentions** show up, flag them as places the change should also update the docs.
-5. If \`cross_repo:true\` is available (workspace configured), re-run \`sverklo_impact symbol:"${symbol}" cross_repo:true\` — cross-repo contracts are the most expensive category of breakage.
+1. \`lookup symbol:"${symbol}"\` — confirm exactly one definition exists. If there are multiple, pin down which one the change targets before proceeding.
+2. \`impact symbol:"${symbol}"\` — full caller graph. If the result returns a partition plan (> 80 callers), traverse one bucket at a time rather than reading the raw list.
+3. \`test_map symbol:"${symbol}"\` — which tests exercise the callers? Callers with zero test coverage are the highest-risk items.
+4. \`refs symbol:"${symbol}"\` with \`exact:true\` — confirms we haven't missed documentation mentions. If any **Doc mentions** show up, flag them as places the change should also update the docs.
+5. If \`cross_repo:true\` is available (workspace configured), re-run \`impact symbol:"${symbol}" cross_repo:true\` — cross-repo contracts are the most expensive category of breakage.
 
 Deliver a decision memo:
 - **Risk level:** LOW / MEDIUM / HIGH (justify in one sentence)
@@ -238,7 +238,7 @@ Deliver a decision memo:
 - **Cross-repo touches:** if any
 - **Go / no-go:** with a one-line rationale
 
-Attach the evidence ids for every claim so the user can \`sverklo_verify\` your analysis didn't go stale between reading and acting.`;
+Attach the evidence ids for every claim so the user can \`verify\` your analysis didn't go stale between reading and acting.`;
   },
 };
 

--- a/src/server/tool-overrides.test.ts
+++ b/src/server/tool-overrides.test.ts
@@ -6,11 +6,15 @@ import { applyToolOverrides, __resetToolOverrideCache } from "./tool-overrides.j
 // disable-list contract so a refactor can't silently change how tool
 // visibility or descriptions are controlled.
 
+// v0.28.0 tool rename: fixtures use canonical (short) names matching what
+// the real tools advertise post-rename. The disable-list also accepts the
+// legacy `sverklo_*` form (the canonicalizer strips the prefix); that's
+// covered by the "back-compat" tests below.
 const fixture = () => [
-  { name: "sverklo_search", description: "orig search", inputSchema: {} },
-  { name: "sverklo_refs", description: "orig refs", inputSchema: {} },
-  { name: "sverklo_forget", description: "orig forget", inputSchema: {} },
-  { name: "sverklo_remember", description: "orig remember", inputSchema: {} },
+  { name: "search", description: "orig search", inputSchema: {} },
+  { name: "refs", description: "orig refs", inputSchema: {} },
+  { name: "forget", description: "orig forget", inputSchema: {} },
+  { name: "remember", description: "orig remember", inputSchema: {} },
 ];
 
 describe("applyToolOverrides — description overrides", () => {
@@ -27,7 +31,7 @@ describe("applyToolOverrides — description overrides", () => {
   it("returns tools unchanged when no env vars are set", () => {
     const result = applyToolOverrides(fixture());
     expect(result).toHaveLength(4);
-    expect(result.find((t) => t.name === "sverklo_search")?.description).toBe("orig search");
+    expect(result.find((t) => t.name === "search")?.description).toBe("orig search");
   });
 
   it("overrides a tool description via SVERKLO_TOOL_<NAME>_DESCRIPTION", () => {
@@ -35,27 +39,28 @@ describe("applyToolOverrides — description overrides", () => {
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
-    expect(result.find((t) => t.name === "sverklo_search")?.description).toBe(
+    expect(result.find((t) => t.name === "search")?.description).toBe(
       "use only for architecture decisions"
     );
     // Other tools unchanged
-    expect(result.find((t) => t.name === "sverklo_refs")?.description).toBe("orig refs");
+    expect(result.find((t) => t.name === "refs")?.description).toBe("orig refs");
   });
 
-  it("strips sverklo_ prefix when matching env var suffix", () => {
-    // Both SEARCH and REVIEW_DIFF-style names should work.
+  it("matches env var suffix against canonical name (no prefix needed)", () => {
+    // Pre-v0.28.0 a `sverklo_` prefix was stripped before match; post-rename
+    // the canonical name has no prefix and the env-var suffix matches directly.
     process.env.SVERKLO_TOOL_REMEMBER_DESCRIPTION = "project decision log only";
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
-    expect(result.find((t) => t.name === "sverklo_remember")?.description).toBe(
+    expect(result.find((t) => t.name === "remember")?.description).toBe(
       "project decision log only"
     );
   });
 
   it("handles multi-word tool names (underscore-separated)", () => {
     const tools = [
-      { name: "sverklo_review_diff", description: "orig", inputSchema: {} },
+      { name: "review_diff", description: "orig", inputSchema: {} },
     ];
     process.env.SVERKLO_TOOL_REVIEW_DIFF_DESCRIPTION = "strict review";
     __resetToolOverrideCache();
@@ -83,7 +88,7 @@ describe("applyToolOverrides — description overrides", () => {
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
-    expect(result.find((t) => t.name === "sverklo_search")?.description).toBe("orig search");
+    expect(result.find((t) => t.name === "search")?.description).toBe("orig search");
   });
 });
 
@@ -98,24 +103,24 @@ describe("applyToolOverrides — disable list", () => {
   });
 
   it("hides a single tool named in SVERKLO_DISABLED_TOOLS", () => {
-    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_forget";
+    process.env.SVERKLO_DISABLED_TOOLS = "forget";
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
-    expect(result.map((t) => t.name)).not.toContain("sverklo_forget");
+    expect(result.map((t) => t.name)).not.toContain("forget");
     expect(result).toHaveLength(3);
   });
 
   it("hides multiple comma-separated tools", () => {
-    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_forget,sverklo_remember";
+    process.env.SVERKLO_DISABLED_TOOLS = "forget,remember";
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
-    expect(result.map((t) => t.name)).toEqual(["sverklo_search", "sverklo_refs"]);
+    expect(result.map((t) => t.name)).toEqual(["search", "refs"]);
   });
 
   it("trims whitespace in the disabled list", () => {
-    process.env.SVERKLO_DISABLED_TOOLS = " sverklo_forget , sverklo_remember ";
+    process.env.SVERKLO_DISABLED_TOOLS = " forget , remember ";
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
@@ -123,12 +128,31 @@ describe("applyToolOverrides — disable list", () => {
   });
 
   it("ignores unknown tool names in the disabled list (no-op)", () => {
-    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_nonexistent,sverklo_search";
+    process.env.SVERKLO_DISABLED_TOOLS = "nonexistent,search";
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
     expect(result).toHaveLength(3);
-    expect(result.map((t) => t.name)).not.toContain("sverklo_search");
+    expect(result.map((t) => t.name)).not.toContain("search");
+  });
+
+  it("v0.28.0 back-compat: accepts legacy `sverklo_*` names in the disable list", () => {
+    // Users may have SVERKLO_DISABLED_TOOLS=sverklo_forget,sverklo_remember
+    // from before the rename. The canonicalizer strips the prefix so both
+    // forms keep working through the deprecation window.
+    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_forget,sverklo_remember";
+    __resetToolOverrideCache();
+
+    const result = applyToolOverrides(fixture());
+    expect(result.map((t) => t.name)).toEqual(["search", "refs"]);
+  });
+
+  it("v0.28.0 back-compat: mixed legacy + canonical names both apply", () => {
+    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_forget,remember";
+    __resetToolOverrideCache();
+
+    const result = applyToolOverrides(fixture());
+    expect(result.map((t) => t.name)).toEqual(["search", "refs"]);
   });
 });
 
@@ -144,13 +168,13 @@ describe("applyToolOverrides — combined overrides", () => {
 
   it("applies description overrides and disable list together", () => {
     process.env.SVERKLO_TOOL_SEARCH_DESCRIPTION = "custom";
-    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_forget";
+    process.env.SVERKLO_DISABLED_TOOLS = "forget";
     __resetToolOverrideCache();
 
     const result = applyToolOverrides(fixture());
     expect(result).toHaveLength(3);
-    expect(result.find((t) => t.name === "sverklo_search")?.description).toBe("custom");
-    expect(result.find((t) => t.name === "sverklo_forget")).toBeUndefined();
+    expect(result.find((t) => t.name === "search")?.description).toBe("custom");
+    expect(result.find((t) => t.name === "forget")).toBeUndefined();
   });
 });
 
@@ -181,14 +205,14 @@ describe("applyToolOverrides — SVERKLO_PROFILE filter", () => {
     process.env.SVERKLO_PROFILE = "core";
     __resetToolOverrideCache();
     const result = applyToolOverrides(fixture());
-    expect(result.map((t) => t.name)).toEqual(["sverklo_search", "sverklo_refs"]);
+    expect(result.map((t) => t.name)).toEqual(["search", "refs"]);
   });
 
   it("filters to lean profile (keeps memory tools)", () => {
     process.env.SVERKLO_PROFILE = "lean";
     __resetToolOverrideCache();
     const result = applyToolOverrides(fixture());
-    expect(result.map((t) => t.name)).toEqual(["sverklo_search", "sverklo_refs", "sverklo_remember"]);
+    expect(result.map((t) => t.name)).toEqual(["search", "refs", "remember"]);
   });
 
   it("ignores unknown profile names with a warning (no filter applied)", () => {
@@ -200,9 +224,9 @@ describe("applyToolOverrides — SVERKLO_PROFILE filter", () => {
 
   it("composes with disabled list (profile + disabled both apply)", () => {
     process.env.SVERKLO_PROFILE = "lean";
-    process.env.SVERKLO_DISABLED_TOOLS = "sverklo_remember";
+    process.env.SVERKLO_DISABLED_TOOLS = "remember";
     __resetToolOverrideCache();
     const result = applyToolOverrides(fixture());
-    expect(result.map((t) => t.name)).toEqual(["sverklo_search", "sverklo_refs"]);
+    expect(result.map((t) => t.name)).toEqual(["search", "refs"]);
   });
 });

--- a/src/server/tool-overrides.ts
+++ b/src/server/tool-overrides.ts
@@ -57,79 +57,83 @@ let cache: OverrideCache | null = null;
 // Pre-defined profiles. Names match Token Savior's convention.
 // `full` is the implicit default and intentionally absent — when no
 // profile is set we don't filter.
+//
+// v0.28.0: profile entries use canonical (short) tool names. The legacy
+// `sverklo_*` names are also accepted in SVERKLO_DISABLED_TOOLS (we strip
+// the prefix when matching), so users with cached config keep working.
 export const PROFILES: Record<string, string[]> = {
   core: [
     // The 6 tools an agent actually reaches for in 80% of code-intel sessions.
-    // sverklo_status is included so `sverklo doctor`'s tools/call probe and
+    // `status` is included so `sverklo doctor`'s tools/call probe and
     // first-session "is this alive?" checks work without re-flagging the
     // profile. Cost: +1 tool above the original 5; well below Claude Code's
     // tool-choke threshold (~12+).
-    "sverklo_status",
-    "sverklo_search",
-    "sverklo_lookup",
-    "sverklo_overview",
-    "sverklo_refs",
-    "sverklo_impact",
+    "status",
+    "search",
+    "lookup",
+    "overview",
+    "refs",
+    "impact",
   ],
   nav: [
-    "sverklo_search",
-    "sverklo_lookup",
-    "sverklo_overview",
-    "sverklo_refs",
-    "sverklo_impact",
-    "sverklo_deps",
-    "sverklo_context",
-    "sverklo_status",
+    "search",
+    "lookup",
+    "overview",
+    "refs",
+    "impact",
+    "deps",
+    "context",
+    "status",
   ],
   lean: [
-    "sverklo_search",
-    "sverklo_lookup",
-    "sverklo_overview",
-    "sverklo_refs",
-    "sverklo_impact",
-    "sverklo_deps",
-    "sverklo_context",
-    "sverklo_status",
-    "sverklo_remember",
-    "sverklo_recall",
-    "sverklo_review_diff",
+    "search",
+    "lookup",
+    "overview",
+    "refs",
+    "impact",
+    "deps",
+    "context",
+    "status",
+    "remember",
+    "recall",
+    "review_diff",
   ],
   // For agents doing open-ended code research / onboarding. Skips memory,
   // diff/review, audit — keeps the multi-signal investigation surface plus
   // ctx-handle ops for iterative refinement.
   research: [
-    "sverklo_search",
-    "sverklo_search_iterative",
-    "sverklo_investigate",
-    "sverklo_ask",
-    "sverklo_lookup",
-    "sverklo_overview",
-    "sverklo_refs",
-    "sverklo_impact",
-    "sverklo_deps",
-    "sverklo_concepts",
-    "sverklo_patterns",
-    "sverklo_clusters",
-    "sverklo_verify",
-    "sverklo_critique",
-    "sverklo_ctx_slice",
-    "sverklo_ctx_grep",
-    "sverklo_ctx_stats",
-    "sverklo_status",
+    "search",
+    "search_iterative",
+    "investigate",
+    "ask",
+    "lookup",
+    "overview",
+    "refs",
+    "impact",
+    "deps",
+    "concepts",
+    "patterns",
+    "clusters",
+    "verify",
+    "critique",
+    "ctx_slice",
+    "ctx_grep",
+    "ctx_stats",
+    "status",
   ],
   // PR/MR review focus — diff tools front-and-center, plus the impact/refs
   // graph to validate refactor safety.
   review: [
-    "sverklo_review_diff",
-    "sverklo_diff_search",
-    "sverklo_test_map",
-    "sverklo_impact",
-    "sverklo_refs",
-    "sverklo_lookup",
-    "sverklo_search",
-    "sverklo_investigate",
-    "sverklo_verify",
-    "sverklo_status",
+    "review_diff",
+    "diff_search",
+    "test_map",
+    "impact",
+    "refs",
+    "lookup",
+    "search",
+    "investigate",
+    "verify",
+    "status",
   ],
 };
 
@@ -141,6 +145,13 @@ function normalizeEnvSuffix(name: string): string {
   return stripped.toUpperCase();
 }
 
+// v0.28.0: tools advertise canonical (short) names but users may still have
+// SVERKLO_DISABLED_TOOLS=sverklo_forget,sverklo_recall in their config. Strip
+// the legacy prefix so both forms work during the deprecation window.
+function canonicalize(name: string): string {
+  return name.startsWith("sverklo_") ? name.slice("sverklo_".length) : name;
+}
+
 function buildCache(): OverrideCache {
   const disabled = new Set<string>();
   const descriptions = new Map<string, string>();
@@ -149,7 +160,7 @@ function buildCache(): OverrideCache {
   if (disabledList) {
     for (const raw of disabledList.split(",")) {
       const name = raw.trim();
-      if (name) disabled.add(name);
+      if (name) disabled.add(canonicalize(name));
     }
   }
 
@@ -232,7 +243,9 @@ export function __resetToolOverrideCache(): void {
  */
 export function isToolEnabled(name: string): boolean {
   const { disabled, profile } = getCache();
-  if (disabled.has(name)) return false;
-  if (profile && !profile.has(name)) return false;
+  // v0.28.0: callers may still pass legacy `sverklo_*` names. Canonicalize.
+  const canonical = canonicalize(name);
+  if (disabled.has(canonical)) return false;
+  if (profile && !profile.has(canonical)) return false;
   return true;
 }

--- a/src/server/tools/ask.ts
+++ b/src/server/tools/ask.ts
@@ -14,14 +14,14 @@ import { emitForHits } from "../../memory/evidence-emit.js";
 // never generated prose).
 
 export const askTool = {
-  name: "sverklo_ask",
+  name: "ask",
   description:
     "Natural-language router over sverklo's existing primitives. " +
     "Maps a question to (a) the closest concept (if the concept index exists), " +
     "(b) an investigate fan-out, and (c) refs/impact on the top symbols surfaced. " +
     "Returns a structured answer with evidence — no generated prose. Use when you " +
     "want a single keystroke that exercises the whole stack; for fine-grained " +
-    "control prefer sverklo_search / sverklo_investigate / sverklo_refs.",
+    "control prefer search / investigate / refs.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -45,7 +45,7 @@ export async function handleAsk(
 ): Promise<string> {
   const query = args.query;
   if (typeof query !== "string" || query.trim() === "") {
-    return "sverklo_ask requires a non-empty `query`.";
+    return "ask requires a non-empty `query`.";
   }
   const scope = args.scope as string | undefined;
   const mode = (args.mode as "fast" | "thorough" | undefined) ?? "fast";
@@ -95,19 +95,19 @@ export async function handleAsk(
     if (topSymbol) {
       const callerCount = indexer.symbolRefStore.getCallerCount(topSymbol);
       lines.push(`## Likely entry symbol: \`${topSymbol}\` — ${callerCount} caller(s)`);
-      lines.push(`_Drill in: \`sverklo_impact symbol:"${topSymbol}"\` for the full caller graph._`);
+      lines.push(`_Drill in: \`impact symbol:"${topSymbol}"\` for the full caller graph._`);
       lines.push("");
     }
   }
 
   lines.push(
-    `_Mode: ${mode}. Drill in: \`sverklo_investigate query:"${query}"\` for the raw fan-out, or \`sverklo_search_iterative\` for a wider pool with refinement hints._`
+    `_Mode: ${mode}. Drill in: \`investigate query:"${query}"\` for the raw fan-out, or \`search_iterative\` for a wider pool with refinement hints._`
   );
 
   // Bug-bash 2 finding #3: the description promised "evidence + hits, no
   // generated prose" but no `ev_` ids were ever emitted, so any agent
-  // that called sverklo_verify on the output got "non-string id".
-  // Emit the same per-hit evidence footer that sverklo_investigate uses.
+  // that called verify on the output got "non-string id".
+  // Emit the same per-hit evidence footer that investigate uses.
   const maxHits = Math.min(8, inv.hits.length);
   const { footer } = emitForHits(
     indexer,

--- a/src/server/tools/ast-grep.ts
+++ b/src/server/tools/ast-grep.ts
@@ -4,11 +4,11 @@ import { resolve as resolvePath, sep } from "node:path";
 import type { IndexFiles } from "../../indexer/index-files.js";
 
 export const astGrepTool = {
-  name: "sverklo_ast_grep",
+  name: "ast_grep",
   description:
     "Find code by AST shape, not text — e.g. 'every console.log($X)', " +
     "'every catch (e) { return null }'. Requires ast-grep on PATH. Pick this " +
-    "over sverklo_search when you need exact structural matches (consistent " +
+    "over search when you need exact structural matches (consistent " +
     "transformations, lint-style queries) and over Grep when you need to " +
     "ignore identifier names or whitespace. Falls back to a clear error if " +
     "ast-grep is missing.",

--- a/src/server/tools/audit.ts
+++ b/src/server/tools/audit.ts
@@ -7,12 +7,12 @@ import { analyzeCodebase, isVendoredPath } from "../audit-analysis.js";
 import { getAuditHistory, formatTrend } from "../../utils/audit-history.js";
 
 export const auditTool = {
-  name: "sverklo_audit",
+  name: "audit",
   description:
     "One-call codebase health report: god nodes (highest blast-radius symbols), " +
     "hub files (highest PageRank), orphan symbols (likely dead code), and " +
     "language/memory stats. Use as the seed for a code-quality pass — pair " +
-    "with sverklo_impact for blast-radius and sverklo_deps for fan-in/fan-out. " +
+    "with impact for blast-radius and deps for fan-in/fan-out. " +
     "Cheaper than running overview + impact + dependencies separately.",
   inputSchema: {
     type: "object" as const,
@@ -34,7 +34,7 @@ interface GodNode {
 export function handleAudit(indexer: IndexFiles & IndexCode & IndexGraph & IndexMemory, args: Record<string, unknown>): string {
   const tokenBudget = resolveBudget(args, "audit", null, 4000);
   // Default-exclude vendored / cached / generated paths from EVERY
-  // audit dimension. Without this, running sverklo_audit against a
+  // audit dimension. Without this, running audit against a
   // workspace whose index includes `<repo>/benchmark/.cache/<vendor>`
   // bubbled third-party HTTP-verb methods to the top of the god-node
   // ranking and made every hub file an express dependency. Dogfood
@@ -323,7 +323,7 @@ export function handleAudit(indexer: IndexFiles & IndexCode & IndexGraph & Index
     memLines.push(`- **${coreMemories.length}** core memories (auto-injected each session)`);
     memLines.push(`- **${memoryCount - coreMemories.length}** archive memories (searched on demand)`);
     if (staleMemories.length > 0) {
-      memLines.push(`- **${staleMemories.length}** stale memories — consider \`sverklo_forget\` or \`sverklo_remember\` to update`);
+      memLines.push(`- **${staleMemories.length}** stale memories — consider \`forget\` or \`remember\` to update`);
     }
     memLines.push("");
     if (!addSection(memLines.join("\n"))) return sections.join("\n");
@@ -383,7 +383,7 @@ export function handleAudit(indexer: IndexFiles & IndexCode & IndexGraph & Index
     const suggestLines: string[] = [];
     suggestLines.push(`## Suggested Next Steps`);
     if (godNodes.length > 0) {
-      suggestLines.push(`- Before refactoring **${godNodes[0].name}**, run \`sverklo_impact\` to see the ${godNodes[0].refCount} call sites`);
+      suggestLines.push(`- Before refactoring **${godNodes[0].name}**, run \`impact\` to see the ${godNodes[0].refCount} call sites`);
     }
     if (hubFiles[0]) {
       suggestLines.push(`- \`${hubFiles[0].path}\` is your most-imported file — changes here cascade widely`);

--- a/src/server/tools/clusters.ts
+++ b/src/server/tools/clusters.ts
@@ -2,11 +2,11 @@ import type { IndexGraph } from "../../indexer/index-graph.js";
 import { detectClusters, type FileCluster } from "../../search/cluster.js";
 
 export const clustersTool = {
-  name: "sverklo_clusters",
+  name: "clusters",
   description:
     "Group files into modules by graph-community detection (label propagation " +
     "over the import graph). Returns 3+ file clusters with their hub file. Use " +
-    "this on first contact with an unfamiliar repo — pair with sverklo_concepts " +
+    "this on first contact with an unfamiliar repo — pair with concepts " +
     "(after running `sverklo concept-index`) for an LLM-named summary of each " +
     "cluster. Skip if the codebase has fewer than ~20 source files; structure " +
     "won't be informative.",
@@ -30,7 +30,7 @@ export function handleClusters(
   // Gather files and edges from the index
   const files = indexer.fileStore.getAll();
   if (files.length === 0) {
-    return "No files indexed yet. Run sverklo_status to check indexing progress.";
+    return "No files indexed yet. Run status to check indexing progress.";
   }
 
   const allEdges = indexer.graphStore.getAll();

--- a/src/server/tools/concepts.ts
+++ b/src/server/tools/concepts.ts
@@ -2,7 +2,7 @@ import type { IndexMemory } from "../../indexer/index-memory.js";
 import { cosineSimilarity } from "../../indexer/embedder.js";
 
 export const conceptsTool = {
-  name: "sverklo_concepts",
+  name: "concepts",
   description:
     "Semantic search over LLM-labeled subsystem concepts. Returns the clusters " +
     "whose label/summary best matches the query, along with each cluster's hub file. " +
@@ -31,7 +31,7 @@ export async function handleConcepts(
 ): Promise<string> {
   const query = args.query;
   if (typeof query !== "string" || query.trim() === "") {
-    return "sverklo_concepts requires a non-empty `query` string.";
+    return "concepts requires a non-empty `query` string.";
   }
   const limit = typeof args.limit === "number" ? args.limit : 5;
 
@@ -44,13 +44,13 @@ export async function handleConcepts(
       "install with a chat-capable model (default: qwen2.5-coder:7b). If you don't have",
       "Ollama yet: https://ollama.com — then `ollama pull qwen2.5-coder:7b`.",
       "",
-      "Until then, use `sverklo_clusters` for the raw, unlabeled cluster list.",
+      "Until then, use `clusters` for the raw, unlabeled cluster list.",
     ].join("\n");
   }
 
   const [qVec] = await indexer.embed([query]);
   if (!qVec) {
-    return "Embedding the query failed. Retry, or fall back to sverklo_search.";
+    return "Embedding the query failed. Retry, or fall back to search.";
   }
 
   const embeddings = indexer.conceptStore.getAllEmbeddings();
@@ -70,7 +70,7 @@ export async function handleConcepts(
       `No concept scored above 0.15 cosine similarity. Top candidate: ${top[0]?.score.toFixed(3) ?? "n/a"}.`
     );
     parts.push(
-      "Try a broader phrasing, or use `sverklo_investigate` — it fans out across multiple retrievers."
+      "Try a broader phrasing, or use `investigate` — it fans out across multiple retrievers."
     );
     return parts.join("\n");
   }
@@ -85,6 +85,6 @@ export async function handleConcepts(
     parts.push("");
   }
 
-  parts.push("_Use `sverklo_lookup` or `sverklo_refs` on the hub file's exported symbols to drill in._");
+  parts.push("_Use `lookup` or `refs` on the hub file's exported symbols to drill in._");
   return parts.join("\n");
 }

--- a/src/server/tools/context.ts
+++ b/src/server/tools/context.ts
@@ -1,4 +1,4 @@
-// sverklo_context: umbrella "give me everything relevant to this task" tool.
+// context: umbrella "give me everything relevant to this task" tool.
 //
 // Inspired by code-review-graph's get_minimal_context. Instead of forcing the
 // model to chain 5-8 atomic calls (overview → search → lookup → recall → ...)
@@ -21,7 +21,7 @@ import { estimateTokens } from "../../utils/tokens.js";
 import type { CodeChunk, FileRecord } from "../../types/index.js";
 
 export const contextTool = {
-  name: "sverklo_context",
+  name: "context",
   description:
     "Umbrella context bundler. Give a task description and get a single curated bundle: " +
     "codebase overview header, semantically relevant code, related symbols, and matching " +
@@ -202,11 +202,11 @@ export async function handleContext(
   if (topResults.length > 0) {
     const top = topResults[0];
     if (top.chunk.name) {
-      parts.push(`- \`sverklo_refs symbol:"${top.chunk.name}"\` to see who uses the most relevant symbol`);
-      parts.push(`- \`sverklo_lookup symbol:"${top.chunk.name}"\` for the full definition`);
+      parts.push(`- \`refs symbol:"${top.chunk.name}"\` to see who uses the most relevant symbol`);
+      parts.push(`- \`lookup symbol:"${top.chunk.name}"\` for the full definition`);
     }
   }
-  parts.push(`- \`sverklo_search query:"<more specific term>"\` to drill into a sub-area`);
+  parts.push(`- \`search query:"<more specific term>"\` to drill into a sub-area`);
   if (detail !== "full") {
     parts.push(`- Re-run with \`detail_level:"full"\` to also see dependency neighbours`);
   }
@@ -381,7 +381,7 @@ async function buildPrunedRepoMap(
     if (cost > remaining) {
       const fallback =
         `## \`${file.path}\` · PR ${file.pagerank.toFixed(3)}\n` +
-        `- _${chunks.length} symbols (budget exhausted — use sverklo_lookup for details)_\n`;
+        `- _${chunks.length} symbols (budget exhausted — use lookup for details)_\n`;
       const fallbackCost = estimateTokens(fallback);
       if (fallbackCost <= remaining) {
         parts.push(fallback);
@@ -408,7 +408,7 @@ async function buildPrunedRepoMap(
   );
   if (filesRendered > 0) {
     parts.push(
-      "_Use `sverklo_lookup symbol:<symbol>` or `sverklo_search query:<...>` to drill into any symbol._"
+      "_Use `lookup symbol:<symbol>` or `search query:<...>` to drill into any symbol._"
     );
   }
 

--- a/src/server/tools/critique.ts
+++ b/src/server/tools/critique.ts
@@ -20,7 +20,7 @@ import type { VerifyResult } from "../../types/index.js";
 //     answer acknowledge them?
 
 export const critiqueTool = {
-  name: "sverklo_critique",
+  name: "critique",
   description:
     "Deterministic coverage check for an agent's answer. Takes the evidence ids the agent cited " +
     "plus the symbols it discussed; verifies each evidence is still current and flags whether the " +
@@ -61,7 +61,7 @@ export function handleCritique(
   const claim = typeof args.claim === "string" ? args.claim : null;
 
   if (evidenceIds.length === 0 && symbols.length === 0) {
-    return "sverklo_critique requires at least one of `evidence_ids` or `symbols`.";
+    return "critique requires at least one of `evidence_ids` or `symbols`.";
   }
 
   // 1. Evidence verification.
@@ -157,8 +157,8 @@ function formatCritique(c: CritiqueData): string {
   const parts: string[] = [];
   parts.push(
     c.claim
-      ? `## sverklo_critique — "${c.claim}"`
-      : "## sverklo_critique"
+      ? `## critique — "${c.claim}"`
+      : "## critique"
   );
   parts.push("");
 

--- a/src/server/tools/ctx-handles.ts
+++ b/src/server/tools/ctx-handles.ts
@@ -9,7 +9,7 @@ import { getGitState } from "../../memory/git-state.js";
 // survive across MCP sessions and detect git-SHA drift.
 
 export const ctxSliceTool = {
-  name: "sverklo_ctx_slice",
+  name: "ctx_slice",
   description:
     "Return a byte-slice of a context handle (ctx://<tool>/<id>). Use to drill into the body without " +
     "rerunning the original retrieval. Returns 'expired' if the handle's pinned SHA no longer matches.",
@@ -25,7 +25,7 @@ export const ctxSliceTool = {
 };
 
 export const ctxGrepTool = {
-  name: "sverklo_ctx_grep",
+  name: "ctx_grep",
   description:
     "Filter the result blocks of a context handle by regex. Operates on the cached body — no second " +
     "retrieval. Returns the narrowed body inline.",
@@ -41,7 +41,7 @@ export const ctxGrepTool = {
 };
 
 export const ctxStatsTool = {
-  name: "sverklo_ctx_stats",
+  name: "ctx_stats",
   description:
     "Inspect a context handle without consuming it: tool, age, block count, byte size, fresh/expired.",
   inputSchema: {

--- a/src/server/tools/dependencies.ts
+++ b/src/server/tools/dependencies.ts
@@ -3,7 +3,7 @@ import type { FileRecord } from "../../types/index.js";
 import { resolveBudget } from "../../utils/budget.js";
 
 export const dependenciesTool = {
-  name: "sverklo_deps",
+  name: "deps",
   description:
     "Show what a file imports/depends on and what depends on it. Helps understand the impact of changing a file.",
   inputSchema: {
@@ -48,8 +48,8 @@ export function handleDependencies(
 
   // Lenient path lookup: accept verbatim, "./prefixed", or
   // "projectName/src/..." forms. Without this, the path format the
-  // sverklo_audit output prints ("sverklo/src/foo.ts" when the project
-  // is in a workspace) doesn't paste into sverklo_deps. Dogfood T5.
+  // audit output prints ("sverklo/src/foo.ts" when the project
+  // is in a workspace) doesn't paste into deps. Dogfood T5.
   const file = indexer.fileStore.findByPath(path);
   if (!file) {
     return `File not found in index: ${path}`;

--- a/src/server/tools/diff-search.ts
+++ b/src/server/tools/diff-search.ts
@@ -8,7 +8,7 @@ import { resolveBudget } from "../../utils/budget.js";
 import { validateGitRef } from "../../utils/git-validation.js";
 
 export const diffSearchTool = {
-  name: "sverklo_diff_search",
+  name: "diff_search",
   description:
     "Semantic search scoped to files in a git diff (and optionally their dependency closure). " +
     "Use this when reviewing an MR/PR and you need to find code related to a query — but only " +
@@ -71,7 +71,7 @@ export async function handleDiffSearch(
     const out = result.stdout;
     changedPaths = out.trim().split("\n").filter(Boolean);
   } catch {
-    return `Error: not a git repository or invalid ref \`${ref}\`. Try \`sverklo_diff_search query:"..." ref:"HEAD~1..HEAD"\`.`;
+    return `Error: not a git repository or invalid ref \`${ref}\`. Try \`diff_search query:"..." ref:"HEAD~1..HEAD"\`.`;
   }
 
   if (changedPaths.length === 0) {

--- a/src/server/tools/find-references.ts
+++ b/src/server/tools/find-references.ts
@@ -5,7 +5,7 @@ import { resolveBudget } from "../../utils/budget.js";
 import { rerank, rerankerConfigFromEnv } from "../../search/rerank.js";
 
 export const findReferencesTool = {
-  name: "sverklo_refs",
+  name: "refs",
   description:
     "Find all references to a symbol across the codebase. Shows where a function, class, or type is imported, called, or used. Matches on identifier word boundaries by default — `embed` does NOT match `embeddingStore`. Pass `exact: false` to opt into substring matching.",
   inputSchema: {
@@ -61,7 +61,7 @@ export async function handleFindReferences(
 ): Promise<string> {
   const symbol = args.symbol;
   if (typeof symbol !== "string" || symbol.trim() === "") {
-    return 'Error: `symbol` is required. Usage: sverklo_refs symbol:"MyClass".';
+    return 'Error: `symbol` is required. Usage: refs symbol:"MyClass".';
   }
   const exact = args.exact !== false; // default true
   const tokenBudget = resolveBudget(args, "refs", null, 2000);
@@ -151,7 +151,7 @@ export async function handleFindReferences(
   // by rerank score instead — keeps file diversity (one chunk per
   // file maximum, so a chunky file can't monopolize the candidates).
   // Issue #29 wiring: this is the second of two paths the bench
-  // primitives now exercise (the first is sverklo_lookup).
+  // primitives now exercise (the first is lookup).
   let sortedFiles: [string, { line: number; context: string; type: string }[]][];
   const refsRerankConfig = rerankerConfigFromEnv();
   if (refsRerankConfig.mode !== "off" && firstChunkPerFile.size > 1) {

--- a/src/server/tools/forget.ts
+++ b/src/server/tools/forget.ts
@@ -1,13 +1,13 @@
 import type { IndexMemory } from "../../indexer/index-memory.js";
 
 export const forgetTool = {
-  name: "sverklo_forget",
+  name: "forget",
   description:
     "Permanently delete a memory after recall returned a stale or wrong entry. " +
-    "Prefer sverklo_remember (with the new content) over forget+remember when " +
+    "Prefer remember (with the new content) over forget+remember when " +
     "superseding a decision — supersession preserves the audit trail via " +
     "valid_until_sha + superseded_by; forget loses it. Get IDs from " +
-    "sverklo_recall or sverklo_memories.",
+    "recall or memories.",
   inputSchema: {
     type: "object" as const,
     properties: {

--- a/src/server/tools/impact.ts
+++ b/src/server/tools/impact.ts
@@ -10,7 +10,7 @@ import {
 } from "../../search/partition.js";
 
 export const impactTool = {
-  name: "sverklo_impact",
+  name: "impact",
   description:
     "Refactor blast-radius: callers of a symbol with confidence scoring. Run before editing. Use cross_repo:true to see impact across linked projects in a workspace.",
   inputSchema: {

--- a/src/server/tools/index-status.test.ts
+++ b/src/server/tools/index-status.test.ts
@@ -55,8 +55,8 @@ describe("handleIndexStatus", () => {
 
   it("includes recommended-workflow suggestions", () => {
     const out = handleIndexStatus(indexer);
-    expect(out).toContain("sverklo_search");
-    expect(out).toContain("sverklo_overview");
+    expect(out).toContain("search");
+    expect(out).toContain("overview");
   });
 
   it("stale-binary warning fires when the binary mtime is ahead of process start", () => {

--- a/src/server/tools/index-status.ts
+++ b/src/server/tools/index-status.ts
@@ -93,7 +93,7 @@ function isBinaryStale(): boolean {
 }
 
 export const indexStatusTool = {
-  name: "sverklo_status",
+  name: "status",
   description:
     "Project state + tool usage guide. Returns index health (files, chunks, languages), " +
     "memory summary, and specific tool recommendations tailored to this codebase. Call this " +
@@ -191,7 +191,7 @@ export function handleIndexStatus(indexer: Indexer): string {
     parts.push(`## Memory`);
     parts.push(`- ${memCount} active memories (${coreMemories.length} core, ${memCount - coreMemories.length} archive)`);
     if (staleMemories.length > 0) {
-      parts.push(`- ⚠️ ${staleMemories.length} stale memories (run \`sverklo_memories stale_only:true\` to review)`);
+      parts.push(`- ⚠️ ${staleMemories.length} stale memories (run \`memories stale_only:true\` to review)`);
     }
     parts.push("");
   }
@@ -203,39 +203,39 @@ export function handleIndexStatus(indexer: Indexer): string {
   const tips: string[] = [];
 
   // Issue #36 (HaleTom 2026-05-13): only recommend tools that are actually
-  // exposed in the current profile. The user reported sverklo_recall being
+  // exposed in the current profile. The user reported recall being
   // hinted while not loaded under SVERKLO_PROFILE=core — a confidence-
   // erosion bug because the agent then tries a non-existent tool.
   const has = isToolEnabled;
 
   if (status.fileCount === 0) {
-    tips.push("- Index is empty. Wait a moment for initial indexing, then call `sverklo_status` again.");
+    tips.push("- Index is empty. Wait a moment for initial indexing, then call `status` again.");
   } else {
-    if (has("sverklo_overview"))
-      tips.push("- **Starting work?** Call `sverklo_overview` to see the top files by PageRank");
-    if (has("sverklo_search"))
-      tips.push("- **Searching for code?** Use `sverklo_search \"natural language query\"` — preferred over Grep");
-    if (has("sverklo_impact"))
-      tips.push("- **Refactoring a function?** Call `sverklo_impact \"functionName\"` FIRST to see blast radius");
-    if (has("sverklo_deps"))
-      tips.push("- **Need to understand a file?** Call `sverklo_deps path:\"src/foo.ts\"` for its import graph");
+    if (has("overview"))
+      tips.push("- **Starting work?** Call `overview` to see the top files by PageRank");
+    if (has("search"))
+      tips.push("- **Searching for code?** Use `search \"natural language query\"` — preferred over Grep");
+    if (has("impact"))
+      tips.push("- **Refactoring a function?** Call `impact \"functionName\"` FIRST to see blast radius");
+    if (has("deps"))
+      tips.push("- **Need to understand a file?** Call `deps path:\"src/foo.ts\"` for its import graph");
   }
 
   if (memCount === 0) {
-    if (has("sverklo_remember")) {
-      tips.push("- **No memories yet.** Use `sverklo_remember` to save decisions, patterns, and preferences");
+    if (has("remember")) {
+      tips.push("- **No memories yet.** Use `remember` to save decisions, patterns, and preferences");
       tips.push("  Example: \"We chose Prisma over Drizzle for better TypeScript types\"");
     }
   } else {
-    if (has("sverklo_recall"))
-      tips.push("- **Check past decisions** with `sverklo_recall \"what did we decide about X\"` before re-inventing");
-    if (coreMemories.length === 0 && has("sverklo_promote")) {
-      tips.push("- No core memories yet. Promote important ones with `sverklo_promote id:<n>` — core memories auto-load each session");
+    if (has("recall"))
+      tips.push("- **Check past decisions** with `recall \"what did we decide about X\"` before re-inventing");
+    if (coreMemories.length === 0 && has("promote")) {
+      tips.push("- No core memories yet. Promote important ones with `promote id:<n>` — core memories auto-load each session");
     }
   }
 
-  if (status.fileCount > 20 && has("sverklo_audit")) {
-    tips.push("- **Curious about the whole project?** Run `sverklo_audit` for god nodes, hub files, and dead code candidates");
+  if (status.fileCount > 20 && has("audit")) {
+    tips.push("- **Curious about the whole project?** Run `audit` for god nodes, hub files, and dead code candidates");
   }
 
   // Inform the user when running on a slim profile so they know WHY
@@ -257,7 +257,7 @@ export function handleIndexStatus(indexer: Indexer): string {
       parts.push(`- [${m.category}] ${m.content}`);
     }
     if (coreMemories.length > 5) {
-      parts.push(`  _...and ${coreMemories.length - 5} more. See all with \`sverklo_memories\`_`);
+      parts.push(`  _...and ${coreMemories.length - 5} more. See all with \`memories\`_`);
     }
     parts.push("");
   }

--- a/src/server/tools/investigate.ts
+++ b/src/server/tools/investigate.ts
@@ -3,14 +3,14 @@ import { runInvestigate, formatInvestigate } from "../../search/investigate.js";
 import { emitForHits } from "../../memory/evidence-emit.js";
 
 export const investigateTool = {
-  name: "sverklo_investigate",
+  name: "investigate",
   description:
     "Single-call research primitive: fans out to BM25, embeddings, symbol lookup, and " +
     "reference-expansion in parallel; RRF-fuses the candidates; returns one ranked bundle " +
     "with per-hit provenance (which retriever(s) found it). Cheaper than running " +
-    "sverklo_search + sverklo_refs + sverklo_lookup back-to-back. WORKS WELL for open-ended " +
+    "search + refs + lookup back-to-back. WORKS WELL for open-ended " +
     "questions where you don't yet know whether the answer lives in code, callers, or " +
-    "documentation — the `found_by` tags tell you which signal agreed. Use sverklo_search " +
+    "documentation — the `found_by` tags tell you which signal agreed. Use search " +
     "instead when you already know you want pure text/semantic retrieval.",
   inputSchema: {
     type: "object" as const,
@@ -22,7 +22,7 @@ export const investigateTool = {
       repo: {
         type: "string",
         description:
-          "Optional: name of a registered repo to investigate (see sverklo_list_repos). " +
+          "Optional: name of a registered repo to investigate (see list_repos). " +
           "Defaults to the current workspace. Use this to investigate a sibling project " +
           "that has been sverklo-init'd but isn't the current cwd.",
       },
@@ -58,7 +58,7 @@ export async function handleInvestigate(
 ): Promise<string> {
   const query = args.query as string;
   if (!query || typeof query !== "string") {
-    return "sverklo_investigate requires a `query` string.";
+    return "investigate requires a `query` string.";
   }
   const scope = args.scope as string | undefined;
   const budget = typeof args.budget === "number" ? args.budget : undefined;

--- a/src/server/tools/list-repos.ts
+++ b/src/server/tools/list-repos.ts
@@ -1,7 +1,7 @@
 import { getRegistry } from "../../registry/registry.js";
 
 export const listReposTool = {
-  name: "sverklo_list_repos",
+  name: "list_repos",
   description:
     "List all indexed repositories in the global registry. " +
     "Use this to discover available repos when running in global (multi-repo) mode. " +

--- a/src/server/tools/lookup.ts
+++ b/src/server/tools/lookup.ts
@@ -4,13 +4,13 @@ import type { FileRecord, ChunkType, SearchResult, CodeChunk } from "../../types
 import { resolveBudget } from "../../utils/budget.js";
 import { rerank, rerankerConfigFromEnv } from "../../search/rerank.js";
 
-// Issue #6: on the first call, sverklo_lookup paid a ~1.6s penalty while
+// Issue #6: on the first call, lookup paid a ~1.6s penalty while
 // warming up prepared statements via fileStore.getAll() to build a
 // pagerank-by-file map. The getByNameWithFile JOIN below returns the
 // same shape in a single indexed query, eliminating the full scan.
 
 export const lookupTool = {
-  name: "sverklo_lookup",
+  name: "lookup",
   description:
     "Look up a specific symbol (function, class, type, variable) by name. Returns its full definition, signature, and location.",
   inputSchema: {
@@ -23,7 +23,7 @@ export const lookupTool = {
       repo: {
         type: "string",
         description:
-          "Optional: name of a registered repo to search (see sverklo_list_repos). " +
+          "Optional: name of a registered repo to search (see list_repos). " +
           "Defaults to the current workspace. Use this to look up a symbol in a sibling " +
           "project that has been sverklo-init'd but isn't the current cwd.",
       },
@@ -61,7 +61,7 @@ export async function handleLookup(
   const symbol = args.symbol;
   if (typeof symbol !== "string" || symbol.trim() === "") {
     return (
-      'Error: `symbol` is required. Usage: sverklo_lookup symbol:"MyClass".\n' +
+      'Error: `symbol` is required. Usage: lookup symbol:"MyClass".\n' +
       "The tool schema names this parameter `symbol`, not `name` — common typo."
     );
   }

--- a/src/server/tools/memories.ts
+++ b/src/server/tools/memories.ts
@@ -2,7 +2,7 @@ import type { IndexMemory } from "../../indexer/index-memory.js";
 import type { Memory, MemoryCategory } from "../../types/index.js";
 
 export const memoriesTool = {
-  name: "sverklo_memories",
+  name: "memories",
   description:
     "List all memories for the current project, or surface conflict candidates. " +
     "Default mode shows memory health (staleness, confidence, access frequency). " +
@@ -93,8 +93,8 @@ function formatConflicts(indexer: IndexMemory, limit: number): string {
     "",
     "_These are pairs of active memories that share at least one pin and live in a category " +
       "where contradiction is meaningful (decision / preference / pattern). The bi-temporal model " +
-      "preserves both — the agent or human picks which to invalidate via `sverklo_forget` or " +
-      "supersede via a fresh `sverklo_remember` call._",
+      "preserves both — the agent or human picks which to invalidate via `forget` or " +
+      "supersede via a fresh `remember` call._",
     "",
   ];
 

--- a/src/server/tools/overview.ts
+++ b/src/server/tools/overview.ts
@@ -4,7 +4,7 @@ import { resolveBudget } from "../../utils/budget.js";
 import { isVendoredPath } from "../audit-analysis.js";
 
 export const overviewTool = {
-  name: "sverklo_overview",
+  name: "overview",
   description:
     "Get a structural map of the codebase. Shows the most important files and their key symbols ranked by dependency importance (PageRank). Use this FIRST when starting work on an unfamiliar codebase or directory.",
   inputSchema: {
@@ -51,7 +51,7 @@ export function handleOverview(
   for (const file of files) {
     // Skip vendored / cached / generated paths so the overview reflects
     // the user's own code, not third-party deps. Same exclusion as
-    // sverklo_audit (Dogfood T1 / T4 in the same review pass).
+    // audit (Dogfood T1 / T4 in the same review pass).
     if (isVendoredPath(file.path)) continue;
     if (path) {
       // Match `path` against `file.path` in three positions:
@@ -61,7 +61,7 @@ export function handleOverview(
       //
       // The embedded form handles multi-repo MCP mode where the
       // global registry stores files as "<repo>/src/foo.ts" — without
-      // it, `sverklo_overview path:"src"` returns empty when the
+      // it, `overview path:"src"` returns empty when the
       // server is bound to the parent of the project (the multi-repo
       // workspace shape). Dogfood review 2026-05-14 (Issue C) caught
       // this as a regression of the v0.20.24 T4 fix in workspace mode.

--- a/src/server/tools/patterns.ts
+++ b/src/server/tools/patterns.ts
@@ -5,7 +5,7 @@ import { PATTERN_TAXONOMY, PATTERN_SET } from "../../storage/pattern-store.js";
 // that the LLM tagged with a given design pattern, sorted by confidence.
 
 export const patternsTool = {
-  name: "sverklo_patterns",
+  name: "patterns",
   description:
     "Query the LLM-derived design-pattern annotations on indexed symbols. " +
     "Pass a `pattern` from the closed taxonomy (observer, repository, validator, ...) " +

--- a/src/server/tools/pin.ts
+++ b/src/server/tools/pin.ts
@@ -1,7 +1,7 @@
 import type { IndexMemory } from "../../indexer/index-memory.js";
 
 export const pinTool = {
-  name: "sverklo_pin",
+  name: "pin",
   description:
     "Pin a memory to a specific file or symbol. Pinned memories surface automatically " +
     "when recalling by that file path or symbol name, without needing semantic search.",
@@ -22,7 +22,7 @@ export const pinTool = {
 };
 
 export const unpinTool = {
-  name: "sverklo_unpin",
+  name: "unpin",
   description: "Remove a pin from a memory.",
   inputSchema: {
     type: "object" as const,

--- a/src/server/tools/post-filter.ts
+++ b/src/server/tools/post-filter.ts
@@ -2,7 +2,7 @@ import { responseStore } from "../response-store.js";
 import { grepResults, headResults, ctxPeek } from "../../search/post-filter.js";
 
 export const grepResultsTool = {
-  name: "sverklo_grep_results",
+  name: "grep_results",
   description:
     "Filter the result blocks of a prior sverklo tool call by a regex pattern — " +
     "operates on the cached text so no second retrieval happens. Pass the " +
@@ -18,7 +18,7 @@ export const grepResultsTool = {
 };
 
 export const headResultsTool = {
-  name: "sverklo_head_results",
+  name: "head_results",
   description:
     "Keep only the top N result blocks of a prior sverklo tool call. Cheap way " +
     "to shrink a chatty response when you just need the top hit.",
@@ -33,7 +33,7 @@ export const headResultsTool = {
 };
 
 export const ctxPeekTool = {
-  name: "sverklo_ctx_peek",
+  name: "ctx_peek",
   description:
     "Return a byte-slice from a single result block of a prior tool call. " +
     "Use when the agent needs to inspect a specific offset without the full body.",

--- a/src/server/tools/recall.test.ts
+++ b/src/server/tools/recall.test.ts
@@ -64,8 +64,8 @@ describe("handleRecall — mode=core", () => {
     const indexer = fakeIndexerWithCore([]);
     const out = await handleRecall(indexer, { mode: "core" });
     expect(out).toContain("No core memories");
-    expect(out).toContain("sverklo_promote");
-    expect(out).toContain("sverklo_remember");
+    expect(out).toContain("promote");
+    expect(out).toContain("remember");
   });
 
   it("returns all core memories when populated", async () => {
@@ -108,7 +108,7 @@ describe("handleRecall — mode=core", () => {
     const out = await handleRecall(indexer, { mode: "core" });
     expect(out).toContain("30 core memories");
     expect(out).toContain("soft limit");
-    expect(out).toContain("sverklo_demote");
+    expect(out).toContain("demote");
   });
 
   it("does not warn below the soft limit", async () => {

--- a/src/server/tools/recall.ts
+++ b/src/server/tools/recall.ts
@@ -21,7 +21,7 @@ const RRF_K = 60;
 const CORE_TIER_SOFT_LIMIT = 25;
 
 export const recallTool = {
-  name: "sverklo_recall",
+  name: "recall",
   description:
     "Search memories semantically. Finds past decisions, preferences, and patterns relevant to a query. " +
     "Supports two specialized modes: `mode=core` returns only the always-on project invariants (fast, " +
@@ -116,8 +116,8 @@ export async function handleRecall(
       return (
         "No core memories yet. Core memories are always-on project invariants " +
         "that auto-load each session. Promote an existing memory with " +
-        "`sverklo_promote id:<n> tier:core`, or save a new one with " +
-        "`sverklo_remember ... tier:core`."
+        "`promote id:<n> tier:core`, or save a new one with " +
+        "`remember ... tier:core`."
       );
     }
 
@@ -134,7 +134,7 @@ export async function handleRecall(
       parts.push(
         `⚠️ ${totalCore} core memories — exceeds the soft limit of ${CORE_TIER_SOFT_LIMIT}. ` +
           "Core memories are injected into every session prompt; too many crowds the context " +
-          "window. Demote the least-critical ones with `sverklo_demote id:<n>`."
+          "window. Demote the least-critical ones with `demote id:<n>`."
       );
     }
     return parts.join("\n");

--- a/src/server/tools/remember.ts
+++ b/src/server/tools/remember.ts
@@ -7,7 +7,7 @@ import { validateEnum, requireString } from "./_validation.js";
 const CONFLICT_THRESHOLD = 0.85;
 
 export const rememberTool = {
-  name: "sverklo_remember",
+  name: "remember",
   description:
     "Save a persistent memory tied to git state. Auto-invalidates conflicting prior memories.",
   inputSchema: {
@@ -66,7 +66,7 @@ export async function handleRemember(
   const contentArg = requireString(
     args.content,
     "content",
-    'sverklo_remember content:"we picked SQLite for the index" [category:decision] [kind:semantic]'
+    'remember content:"we picked SQLite for the index" [category:decision] [kind:semantic]'
   );
   if (!contentArg.ok) return contentArg.message;
   const content = contentArg.value;

--- a/src/server/tools/rename-aliases.test.ts
+++ b/src/server/tools/rename-aliases.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  LEGACY_TOOL_ALIASES,
+  resolveToolName,
+} from "../mcp-server.js";
+
+// Regression tests for v0.28.0 #71 — the MCP tool-name rename.
+//
+// Pre-v0.28.0, tools were named `sverklo_X` and `resolveToolName`
+// didn't exist. The whole file would fail to import on the
+// unpatched code (Principle VI.3). After v0.28.0 these tests
+// lock in three behaviors:
+//
+//   1. The alias map covers every renamed tool (no dropped entries).
+//   2. resolveToolName routes legacy → canonical correctly.
+//   3. The deprecation warning fires exactly once per legacy name
+//      per server instance — agents that call sverklo_search 200
+//      times in a session shouldn't see 200 warnings.
+
+describe("v0.28.0 #71 — legacy tool-name alias resolution", () => {
+  it("exports LEGACY_TOOL_ALIASES with ≥30 entries (the rename was substantive)", () => {
+    expect(Object.keys(LEGACY_TOOL_ALIASES).length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("every alias key has the sverklo_ prefix and every value does NOT", () => {
+    for (const [legacy, canonical] of Object.entries(LEGACY_TOOL_ALIASES)) {
+      expect(legacy.startsWith("sverklo_")).toBe(true);
+      expect(canonical.startsWith("sverklo_")).toBe(false);
+      // The canonical name should be the legacy name minus the prefix.
+      expect(legacy).toBe(`sverklo_${canonical}`);
+    }
+  });
+
+  it("resolveToolName routes a legacy name to its canonical form", () => {
+    const warned = new Set<string>();
+    const messages: string[] = [];
+    const result = resolveToolName("sverklo_search", warned, (m) => messages.push(m));
+    expect(result).toBe("search");
+  });
+
+  it("resolveToolName passes a canonical name through unchanged with no warning", () => {
+    const warned = new Set<string>();
+    const messages: string[] = [];
+    const result = resolveToolName("search", warned, (m) => messages.push(m));
+    expect(result).toBe("search");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("resolveToolName passes an unknown name through unchanged", () => {
+    // e.g. Zilliz compat aliases or any tool we don't know about
+    const warned = new Set<string>();
+    const messages: string[] = [];
+    const result = resolveToolName("totally_unknown_thing", warned, (m) => messages.push(m));
+    expect(result).toBe("totally_unknown_thing");
+    expect(messages).toHaveLength(0);
+  });
+
+  it("emits a deprecation warning the FIRST time a legacy name is seen", () => {
+    const warned = new Set<string>();
+    const messages: string[] = [];
+    resolveToolName("sverklo_search", warned, (m) => messages.push(m));
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("[sverklo:DEPRECATED]");
+    expect(messages[0]).toContain("sverklo_search");
+    expect(messages[0]).toContain("search");
+    expect(messages[0]).toContain("v0.29.0");
+  });
+
+  it("emits the warning EXACTLY ONCE per legacy name, not on every call", () => {
+    // Agents that call sverklo_search 200 times in a single session
+    // shouldn't get 200 warning lines on stderr. The Set<string> in
+    // the dispatch loop is what makes this work.
+    const warned = new Set<string>();
+    const messages: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      resolveToolName("sverklo_search", warned, (m) => messages.push(m));
+    }
+    expect(messages).toHaveLength(1);
+  });
+
+  it("warns separately for different legacy names (one warning each)", () => {
+    const warned = new Set<string>();
+    const messages: string[] = [];
+    resolveToolName("sverklo_search", warned, (m) => messages.push(m));
+    resolveToolName("sverklo_lookup", warned, (m) => messages.push(m));
+    resolveToolName("sverklo_search", warned, (m) => messages.push(m)); // dup, ignored
+    resolveToolName("sverklo_impact", warned, (m) => messages.push(m));
+    expect(messages).toHaveLength(3); // one per distinct legacy name
+    expect(messages.some((m) => m.includes("sverklo_search"))).toBe(true);
+    expect(messages.some((m) => m.includes("sverklo_lookup"))).toBe(true);
+    expect(messages.some((m) => m.includes("sverklo_impact"))).toBe(true);
+  });
+});

--- a/src/server/tools/repo-param.test.ts
+++ b/src/server/tools/repo-param.test.ts
@@ -45,7 +45,10 @@ describe("v0.24.0 — `repo` param on search-family tool schemas", () => {
     for (const { tool } of tools) {
       const props = tool.inputSchema.properties as Record<string, { description?: string }>;
       const desc = props.repo.description ?? "";
-      expect(desc.toLowerCase()).toContain("sverklo_list_repos");
+      // v0.28.0 (#71): tool names dropped the sverklo_ prefix. The
+      // discovery hint that previously said "sverklo_list_repos" now
+      // says "list_repos". Old name still works via deprecation alias.
+      expect(desc.toLowerCase()).toContain("list_repos");
     }
   });
 });

--- a/src/server/tools/review-diff.ts
+++ b/src/server/tools/review-diff.ts
@@ -12,7 +12,7 @@ import { resolveBudget } from "../../utils/budget.js";
 import { validateGitRef } from "../../utils/git-validation.js";
 
 export const reviewDiffTool = {
-  name: "sverklo_review_diff",
+  name: "review_diff",
   description:
     "Diff-aware context bundler for code review. Takes a git ref or range and returns: " +
     "changed files, semantic delta (added/removed/modified symbols), dangling references " +
@@ -76,7 +76,7 @@ export function handleReviewDiff(
   // ─── 1. Get list of changed files ───
   const changedFiles = getChangedFiles(indexer.rootPath, ref);
   if (changedFiles === null) {
-    return "Error: not a git repository or invalid ref. Try `sverklo_review_diff ref:HEAD~1..HEAD`.";
+    return "Error: not a git repository or invalid ref. Try `review_diff ref:HEAD~1..HEAD`.";
   }
   if (changedFiles.length === 0) {
     return `No file changes between \`${ref}\`. Working tree clean or ref invalid.`;
@@ -388,7 +388,7 @@ export function handleReviewDiff(
           remLines.push(`    · ${f}`);
         }
         if (refs!.files.length > 3) {
-          remLines.push(`    · ...and ${refs!.files.length - 3} more (call sverklo_impact for full list)`);
+          remLines.push(`    · ...and ${refs!.files.length - 3} more (call impact for full list)`);
         }
       }
     }
@@ -478,11 +478,11 @@ export function handleReviewDiff(
         .filter((s) => (danglingRefs.get(s.name)?.count ?? 0) > 0)
         .map((s) => s.name);
       if (dangerNames.length > 0) {
-        recLines.push(`- Run \`sverklo_impact symbol:"${dangerNames[0]}"\` to see all callers of removed symbols`);
+        recLines.push(`- Run \`impact symbol:"${dangerNames[0]}"\` to see all callers of removed symbols`);
       }
     }
     if (modifiedFiles.length > 0) {
-      recLines.push(`- Run \`sverklo_diff_search query:"..."\` to search semantically within these files`);
+      recLines.push(`- Run \`diff_search query:"..."\` to search semantically within these files`);
     }
     if (addedSymbols.length > 0 && duplicateCandidates.length === 0) {
       recLines.push(`- New symbols look unique — no duplication detected against indexed code`);

--- a/src/server/tools/search-iterative.ts
+++ b/src/server/tools/search-iterative.ts
@@ -6,7 +6,7 @@ import { runInvestigate, formatInvestigate } from "../../search/investigate.js";
 import { buildHandleUri } from "../../storage/handle-store.js";
 import { getGitState } from "../../memory/git-state.js";
 
-// Iterative widened-pool search (v0.15, P1-14). Where sverklo_search returns
+// Iterative widened-pool search (v0.15, P1-14). Where search returns
 // the top ~10 hits packed into a token budget, search_iterative widens the
 // pool to ~200, stores the body behind a ctx:// handle, and surfaces
 // query-refinement hints (top co-occurring symbols, dominant directories,
@@ -14,13 +14,13 @@ import { getGitState } from "../../memory/git-state.js";
 // without rerunning retrieval.
 
 export const searchIterativeTool = {
-  name: "sverklo_search_iterative",
+  name: "search_iterative",
   description:
-    "Wider-pool, iterative-friendly variant of sverklo_search. Returns a ctx:// handle to the " +
+    "Wider-pool, iterative-friendly variant of search. Returns a ctx:// handle to the " +
     "top-200 candidate pool plus refinement hints (co-occurring symbols, dominant directories, " +
     "concept overlap). Use ctx_grep / ctx_slice to refine without firing another retrieval. " +
     "Worth the extra latency (~50ms) on hard multi-hop questions; for single-shot lookups " +
-    "use sverklo_search.",
+    "use search.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -33,7 +33,7 @@ export const searchIterativeTool = {
       repo: {
         type: "string",
         description:
-          "Optional: name of a registered repo to search (see sverklo_list_repos). " +
+          "Optional: name of a registered repo to search (see list_repos). " +
           "Defaults to the current workspace. Use this to widen the iterative search " +
           "over a sibling project that has been sverklo-init'd but isn't the current cwd.",
       },
@@ -109,8 +109,8 @@ export async function handleSearchIterative(
 
   // Persist the body as a ctx:// handle.
   const sha = getGitState(indexer.rootPath).sha;
-  const handle = indexer.handleStore.create("sverklo_search_iterative", fullBody, sha);
-  const uri = buildHandleUri("sverklo_search_iterative", handle.id);
+  const handle = indexer.handleStore.create("search_iterative", fullBody, sha);
+  const uri = buildHandleUri("search_iterative", handle.id);
 
   // Build the response: a short summary + hints + handle URI.
   const lines: string[] = [];
@@ -133,7 +133,7 @@ export async function handleSearchIterative(
   if (topSymbols.length > 0) {
     lines.push("### Refinement: co-occurring symbols");
     for (const [sym, n] of topSymbols) {
-      lines.push(`- \`${sym}\` (${n}× in pool) — try \`sverklo_lookup symbol:"${sym}"\``);
+      lines.push(`- \`${sym}\` (${n}× in pool) — try \`lookup symbol:"${sym}"\``);
     }
     lines.push("");
   }
@@ -149,13 +149,13 @@ export async function handleSearchIterative(
   if (conceptHints.length > 0) {
     lines.push("### Refinement: nearest concepts");
     for (const c of conceptHints) {
-      lines.push(`- ${c.label} (sim ${c.score.toFixed(3)}) — try \`sverklo_concepts query:"${c.label}"\``);
+      lines.push(`- ${c.label} (sim ${c.score.toFixed(3)}) — try \`concepts query:"${c.label}"\``);
     }
     lines.push("");
   }
 
   lines.push(
-    `_Drill in: \`sverklo_ctx_grep uri:"${uri}" pattern:"<regex>"\`, \`sverklo_ctx_slice uri:"${uri}" offset:0 length:4000\`._`
+    `_Drill in: \`ctx_grep uri:"${uri}" pattern:"<regex>"\`, \`ctx_slice uri:"${uri}" offset:0 length:4000\`._`
   );
 
   return lines.join("\n");

--- a/src/server/tools/search.ts
+++ b/src/server/tools/search.ts
@@ -8,7 +8,7 @@ import { resolveBudget } from "../../utils/budget.js";
 import { validateEnum, requireString } from "./_validation.js";
 
 export const searchTool = {
-  name: "sverklo_search",
+  name: "search",
   description:
     "Hybrid semantic + text search with PageRank ranking. " +
     "WORKS WELL for: exploratory questions where you don't know the exact symbol " +
@@ -30,7 +30,7 @@ export const searchTool = {
       repo: {
         type: "string",
         description:
-          "Optional: name of a registered repo to search (see sverklo_list_repos). " +
+          "Optional: name of a registered repo to search (see list_repos). " +
           "Defaults to the current workspace. Use this to query a sibling project that " +
           "has been sverklo-init'd but isn't the current cwd — avoids falling back to grep.",
       },
@@ -96,7 +96,7 @@ export async function handleSearch(
   const queryArg = requireString(
     args.query,
     "query",
-    'sverklo_search query:"how does retry logic work" [scope:src/api/] [type:function] [mode:refs|full]'
+    'search query:"how does retry logic work" [scope:src/api/] [type:function] [mode:refs|full]'
   );
   if (!queryArg.ok) return queryArg.message;
   const mode = validateEnum(args.mode, ["refs", "full"], "mode", "full");
@@ -178,7 +178,7 @@ export async function handleSearch(
   }
 
   // Q4: per-hit Evidence rows. Each result gets its own ev_ id the agent
-  // can verify with sverklo_verify. Capped at 16 to keep the footer
+  // can verify with verify. Capped at 16 to keep the footer
   // bounded; oversize result sets get evidence for their top entries.
   // #61: was hardcoded "fts" — now "hybrid" because hybridSearch fuses
   // BM25 + vector + PageRank + RRF, not pure FTS.
@@ -207,7 +207,7 @@ function formatRefsOnly(results: SearchResult[]): string {
   }
   lines.push("");
   lines.push(
-    `_${results.length} ref(s). Re-run with mode:"full" or use sverklo_ctx_slice for bodies._`
+    `_${results.length} ref(s). Re-run with mode:"full" or use ctx_slice for bodies._`
   );
   return lines.join("\n");
 }

--- a/src/server/tools/test-map.ts
+++ b/src/server/tools/test-map.ts
@@ -8,7 +8,7 @@ import { computeRiskScore, formatRiskBadge } from "./risk-score.js";
 import { validateGitRef } from "../../utils/git-validation.js";
 
 export const testMapTool = {
-  name: "sverklo_test_map",
+  name: "test_map",
   description:
     "Map a git diff to its test coverage. Given a ref/range, lists which tests likely cover " +
     "each changed source file (via name heuristics + import graph), flags changed source files " +
@@ -60,7 +60,7 @@ export function handleTestMap(
       // existsSync should never throw; if it does, treat as not-a-repo.
     }
     if (!isGitRepo) {
-      return `Error: \`${indexer.rootPath}\` is not a git repository (no .git found). \`sverklo_test_map\` only works on git-versioned projects.`;
+      return `Error: \`${indexer.rootPath}\` is not a git repository (no .git found). \`test_map\` only works on git-versioned projects.`;
     }
 
     const result = spawnSync(
@@ -85,7 +85,7 @@ export function handleTestMap(
       // 'foo'" — surface the actual message so the user can fix their ref.
       const stderr = (result.stderr || "").trim();
       const hint = stderr.includes("ambiguous argument") || stderr.includes("bad revision")
-        ? ` Try \`sverklo_test_map ref:"HEAD~1..HEAD"\` if HEAD~N is out of range for this repo's history.`
+        ? ` Try \`test_map ref:"HEAD~1..HEAD"\` if HEAD~N is out of range for this repo's history.`
         : "";
       return `Error from \`git diff ${ref}\`: ${stderr || `exit ${result.status}`}.${hint}`;
     }

--- a/src/server/tools/tier.ts
+++ b/src/server/tools/tier.ts
@@ -9,7 +9,7 @@ import type { MemoryTier } from "../../types/index.js";
 const CORE_TIER_SOFT_LIMIT = 25;
 
 export const promoteTool = {
-  name: "sverklo_promote",
+  name: "promote",
   description:
     "Promote a memory to the core tier. Core memories are auto-injected into every session " +
     "via sverklo://context resource — use for project invariants that should always be in the " +
@@ -27,10 +27,10 @@ export const promoteTool = {
 };
 
 export const demoteTool = {
-  name: "sverklo_demote",
+  name: "demote",
   description:
     "Demote a memory from core to archive tier. Archive memories are only retrieved on demand " +
-    "via sverklo_recall — not automatically injected. Use for memories that no longer need " +
+    "via recall — not automatically injected. Use for memories that no longer need " +
     "to be in every session.",
   inputSchema: {
     type: "object" as const,
@@ -82,7 +82,7 @@ function setTier(indexer: IndexMemory, args: Record<string, unknown>, tier: Memo
         base +
         `\n\n⚠️ Core tier now has ${coreCount} memories (soft limit: ${CORE_TIER_SOFT_LIMIT}). ` +
         "These are injected into every session prompt — too many crowds the context window. " +
-        "Consider demoting the least-critical ones with `sverklo_demote id:<n>`."
+        "Consider demoting the least-critical ones with `demote id:<n>`."
       );
     }
   }

--- a/src/server/tools/verify.ts
+++ b/src/server/tools/verify.ts
@@ -3,7 +3,7 @@ import { verifyEvidence } from "../../memory/evidence.js";
 import type { VerifyResult } from "../../types/index.js";
 
 export const verifyTool = {
-  name: "sverklo_verify",
+  name: "verify",
   description:
     "Check whether one or more evidence ids (from a prior search-family tool's " +
     "```evidence block) still point to the same code they did at retrieval time. " +
@@ -34,7 +34,7 @@ export function handleVerify(
 ): string {
   const ids = args.evidence_ids;
   if (!Array.isArray(ids) || ids.length === 0) {
-    return "sverklo_verify requires evidence_ids: string[].";
+    return "verify requires evidence_ids: string[].";
   }
 
   const results: VerifyResult[] = ids.map((id) =>
@@ -64,8 +64,8 @@ function glyph(status: VerifyResult["status"]): string {
 function formatVerify(results: VerifyResult[], claim: string | null): string {
   const parts: string[] = [];
   const header = claim
-    ? `## sverklo_verify — ${results.length} evidence id(s) for "${claim}"`
-    : `## sverklo_verify — ${results.length} evidence id(s)`;
+    ? `## verify — ${results.length} evidence id(s) for "${claim}"`
+    : `## verify — ${results.length} evidence id(s)`;
   parts.push(header);
   parts.push("");
   for (const r of results) {

--- a/src/server/tools/wakeup.ts
+++ b/src/server/tools/wakeup.ts
@@ -2,12 +2,12 @@ import type { IndexFiles } from "../../indexer/index-files.js";
 import type { IndexMemory } from "../../indexer/index-memory.js";
 
 export const wakeupTool = {
-  name: "sverklo_wakeup",
+  name: "wakeup",
   description:
     "500-token codebase summary suitable for pasting into a system prompt " +
     "when the agent has no MCP access. Use this when integrating sverklo " +
     "intelligence into Cursor, Codex, or a CI bot that can't run the MCP " +
-    "server. For MCP-connected agents, prefer sverklo_status and the " +
+    "server. For MCP-connected agents, prefer status and the " +
     "richer per-tool surfaces — they return more and stay in budget.",
   inputSchema: {
     type: "object" as const,
@@ -74,7 +74,7 @@ export function generateWakeup(
     }
   }
 
-  parts.push(`_Sverklo-generated wake-up. For full search, use sverklo_search via MCP._`);
+  parts.push(`_Sverklo-generated wake-up. For full search, use search via MCP._`);
 
   let output = parts.join("\n");
 

--- a/src/server/trajectory.ts
+++ b/src/server/trajectory.ts
@@ -1,10 +1,10 @@
 // P2-18: tool-call trajectory ring buffer.
 //
-// Every dispatched sverklo_* call appends a {tool, args_summary, ts}
-// record into a per-process ring buffer. When sverklo_remember runs, it
-// pulls the recent trajectory and stores it as JSON on the memory row,
-// so future readers can ask "why did we decide this?" and get the
-// concrete sequence of retrievals that led to the decision.
+// Every dispatched first-party tool call appends a {tool, args_summary, ts}
+// record into a per-process ring buffer. When `remember` runs, it pulls the
+// recent trajectory and stores it as JSON on the memory row, so future
+// readers can ask "why did we decide this?" and get the concrete sequence
+// of retrievals that led to the decision.
 //
 // Buffer cap is intentionally small (16 entries) — a memory's
 // provenance is the immediate context, not the whole session.
@@ -18,12 +18,25 @@ export interface TrajectoryEntry {
 
 const MAX_ENTRIES = 16;
 
+// Zilliz claude-context compat names — recorded by their underlying handler
+// already, no point double-recording. Kept here so trajectory has no cyclic
+// import on mcp-server.
+const COMPAT_ALIAS_NAMES = new Set<string>([
+  "index_codebase",
+  "search_code",
+  "clear_index",
+  "get_indexing_status",
+]);
+
 class TrajectoryBuffer {
   private entries: TrajectoryEntry[] = [];
 
   record(tool: string, args: Record<string, unknown>, duration_ms: number): void {
-    if (!tool.startsWith("sverklo_")) return;
-    if (tool === "sverklo_remember") return; // don't record the consumer
+    // v0.28.0: tools no longer carry a `sverklo_` prefix. Skip Zilliz
+    // compat aliases (they're already counted via the underlying handler)
+    // and the `remember` consumer (don't record into our own provenance).
+    if (COMPAT_ALIAS_NAMES.has(tool)) return;
+    if (tool === "remember") return;
     this.entries.push({
       tool,
       args_summary: summariseArgs(args),

--- a/src/skills/sverklo-onboard.md
+++ b/src/skills/sverklo-onboard.md
@@ -5,10 +5,10 @@ description: Get a complete understanding of this codebase using sverklo's code 
 
 When the user asks to understand, explore, or onboard to a codebase:
 
-1. Call `sverklo_context` to get the project overview, saved memories, and codebase map
-2. Call `sverklo_overview` to see the most important files ranked by PageRank
-3. Call `sverklo_audit` to identify god nodes, hub files, and dead code
+1. Call `context` to get the project overview, saved memories, and codebase map
+2. Call `overview` to see the most important files ranked by PageRank
+3. Call `audit` to identify god nodes, hub files, and dead code
 
 Present a summary: what the project does, its key modules, architectural patterns, and any code quality concerns.
 
-**Tool-call budget.** Cap exploratory work at ~5 sverklo calls. If you don't have the answer after `sverklo_overview` + 2-3 targeted `sverklo_search`/`sverklo_lookup` calls, ask a clarifying question instead of issuing a 6th call. Avoid re-reading files you have already read unless they may have changed — when sverklo returns a path, treat it as known.
+**Tool-call budget.** Cap exploratory work at ~5 sverklo calls. If you don't have the answer after `overview` + 2-3 targeted `search`/`lookup` calls, ask a clarifying question instead of issuing a 6th call. Avoid re-reading files you have already read unless they may have changed — when sverklo returns a path, treat it as known.

--- a/src/skills/sverklo-refactor.md
+++ b/src/skills/sverklo-refactor.md
@@ -5,11 +5,11 @@ description: Plan a safe refactor using blast-radius analysis
 
 When the user wants to rename, move, or refactor a symbol:
 
-1. Call `sverklo_impact` on the symbol to see all callers and the blast radius
-2. Call `sverklo_refs` to find every reference (with exact matching to avoid false positives)
-3. Call `sverklo_deps` on the file to understand its dependency context
-4. Call `sverklo_test_map` to identify which tests need updating
+1. Call `impact` on the symbol to see all callers and the blast radius
+2. Call `refs` to find every reference (with exact matching to avoid false positives)
+3. Call `deps` on the file to understand its dependency context
+4. Call `test_map` to identify which tests need updating
 
 Present: the full list of files that need changes, the risk level, and a step-by-step refactor plan.
 
-**Stay in scope.** Modify only what `sverklo_impact` flagged. Do not add docstrings, type annotations, formatting fixes, or "improvements" to code that wasn't part of the refactor — those changes are invisible to the impact analysis and create unrelated review noise. If you spot something worth changing, mention it; do not silently edit it.
+**Stay in scope.** Modify only what `impact` flagged. Do not add docstrings, type annotations, formatting fixes, or "improvements" to code that wasn't part of the refactor — those changes are invisible to the impact analysis and create unrelated review noise. If you spot something worth changing, mention it; do not silently edit it.

--- a/src/skills/sverklo-review.md
+++ b/src/skills/sverklo-review.md
@@ -5,8 +5,8 @@ description: Review the current diff with risk scoring and impact analysis
 
 When the user asks to review changes, a PR, or a diff:
 
-1. Call `sverklo_review_diff` to get risk-scored file analysis, dangling references, and structural warnings
-2. For any high-risk files, call `sverklo_impact` on the changed symbols to see the full blast radius
-3. Call `sverklo_test_map` to check which tests cover the changed code
+1. Call `review_diff` to get risk-scored file analysis, dangling references, and structural warnings
+2. For any high-risk files, call `impact` on the changed symbols to see the full blast radius
+3. Call `test_map` to check which tests cover the changed code
 
 Present: risk summary, files that need attention, untested changes, and suggested next steps.


### PR DESCRIPTION
## Summary

Closes #71. 37 tools renamed at the source — every `sverklo_X` becomes `X`. Clients (Claude Code, opencode, Cursor) add the server-name namespace, so `mcp__sverklo__sverklo_search` becomes `mcp__sverklo__search`. Soft transition via deprecation aliases — every legacy `sverklo_*` name still routes to the same handler for one minor release.

## Deprecation behavior

- `LEGACY_TOOL_ALIASES` map at `mcp-server.ts:104` covers all 37 renames
- First time each legacy name is seen in a server instance, emit a one-time stderr `[sverklo:DEPRECATED]` warning
- `Set<string>` dedup ensures agents calling `sverklo_search` 200x see one warning, not 200
- `tools/list` advertises canonical names only (count stays 37, not 74)
- v0.29.0 (separate ship, later) removes the aliases

## Surface

50 files modified: 30+ tool defs, mcp-server dispatch, `tool-overrides.ts` (SVERKLO_PROFILE filter), `hints.ts`, `prompts.ts`, all skill `.md` files, the SVERKLO_SNIPPET written by `sverklo init`, audit-prompt, bin/sverklo.ts, doctor.

## Tests (Principle VI compliant)

`src/server/tools/rename-aliases.test.ts` (8 new tests) verifies alias coverage, route correctness, and the once-per-name warning dedup. Tests fail on pre-v0.28.0 code at the import level (`resolveToolName` + `LEGACY_TOOL_ALIASES` don't exist).

Pre-existing tests that reference `sverklo_X` tool names continue passing — they exercise the deprecation alias path, which is exactly the dual coverage we want.

**Full suite: 721 passed / 1 skipped / 0 failed across 80 test files.**

## Migration plan

| Version | Behavior |
|---|---|
| v0.28.0 (this PR) | Canonical names work. Legacy names work but log one deprecation warning per name |
| v0.28.x patches | No changes to alias behavior |
| v0.29.0 (planned) | Legacy aliases removed. Calls to `sverklo_*` names fail. Plenty of release runway for users to update |

## Constitution check

- I (Local-first): ✅ no new network paths
- IV (Test-first CI): ✅ tests added, fail-on-unpatched verified at import level
- V (Ship small): one focused feature, soft transition to avoid breaking the world
- VI (Validate the fix, then ship): ✅ source-tree VI verified. VI.4 against built artifact post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)