### PR TITLE
Fix Java impact and PageRank indexing

### DIFF
--- a/src/indexer/graph-builder.ts
+++ b/src/indexer/graph-builder.ts
@@ -57,6 +57,8 @@ const EXTENSIONS = [
   ".php",
 ];
 
+const PACKAGE_IMPORT_EXTENSIONS = [".java", ".kt", ".kts", ".scala", ".groovy"];
+
 export function buildGraph(
   fileImports: Map<string, ImportRef[]>, // relativePath -> imports
   fileStore: FileStore,
@@ -68,6 +70,7 @@ export function buildGraph(
   for (const f of allFiles) {
     pathToId.set(f.path, f.id);
   }
+  const packageImportToId = buildPackageImportIndex(pathToId);
 
   // Clear outgoing edges for every file that was just re-parsed. The
   // incremental reindexFile() path already does this before calling
@@ -95,10 +98,10 @@ export function buildGraph(
     const fileDir = dirname(filePath);
 
     for (const imp of imports) {
-      if (!imp.isRelative) continue;
-
       // Try to resolve the import to a file in the index
-      const resolved = resolveImport(imp.source, fileDir, pathToId);
+      const resolved = imp.isRelative
+        ? resolveImport(imp.source, fileDir, pathToId)
+        : resolvePackageImport(imp.source, packageImportToId);
       if (resolved !== undefined) {
         graphStore.upsert(sourceId, resolved, imp.names.length || 1);
         edges.push({ source: sourceId, target: resolved });
@@ -150,6 +153,43 @@ function resolveImport(
       const id = pathToId.get(normalized);
       if (id !== undefined) return id;
     }
+  }
+
+  return undefined;
+}
+
+function buildPackageImportIndex(pathToId: Map<string, number>): Map<string, number> {
+  const suffixToId = new Map<string, number>();
+
+  for (const [filePath, id] of pathToId) {
+    const normalized = filePath.replace(/\\/g, "/");
+    const extension = PACKAGE_IMPORT_EXTENSIONS.find((ext) => normalized.endsWith(ext));
+    if (!extension) continue;
+
+    const withoutExtension = normalized.slice(0, -extension.length);
+    const parts = withoutExtension.split("/");
+    for (let i = 0; i < parts.length; i++) {
+      const suffix = `${parts.slice(i).join("/")}${extension}`;
+      if (!suffixToId.has(suffix)) {
+        suffixToId.set(suffix, id);
+      }
+    }
+  }
+
+  return suffixToId;
+}
+
+function resolvePackageImport(
+  importPath: string,
+  packageImportToId: Map<string, number>
+): number | undefined {
+  const source = importPath.trim();
+  if (!source || source.endsWith(".*")) return undefined;
+
+  const basePath = source.replace(/\./g, "/");
+  for (const extension of PACKAGE_IMPORT_EXTENSIONS) {
+    const id = packageImportToId.get(`${basePath}${extension}`);
+    if (id !== undefined) return id;
   }
 
   return undefined;

--- a/src/indexer/indexer-java.test.ts
+++ b/src/indexer/indexer-java.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Indexer } from "./indexer.js";
+import { getProjectConfig } from "../utils/config.js";
+
+describe("Indexer Java impact graph", () => {
+  let root: string;
+  const originalModelDir = process.env.SVERKLO_MODEL_DIR;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "sverklo-java-"));
+    process.env.SVERKLO_MODEL_DIR = join(process.cwd(), "models");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (originalModelDir === undefined) {
+      delete process.env.SVERKLO_MODEL_DIR;
+    } else {
+      process.env.SVERKLO_MODEL_DIR = originalModelDir;
+    }
+  });
+
+  function write(relativePath: string, content: string): void {
+    const path = join(root, relativePath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+  }
+
+  it("connects Java imports and type-only references to impact and PageRank", async () => {
+    write(
+      "src/main/java/com/example/core/context/PartitionedHandler.java",
+      [
+        "package com.example.core.context;",
+        "",
+        "public abstract class PartitionedHandler<T> {",
+        "  public abstract void handle(T value);",
+        "}",
+      ].join("\n"),
+    );
+    write(
+      "src/main/java/com/example/app/ProcessTask.java",
+      [
+        "package com.example.app;",
+        "",
+        "import com.example.core.context.PartitionedHandler;",
+        "",
+        "public class ProcessTask {",
+        "  private final PartitionedHandler<ProcessTask> service;",
+        "",
+        "  public ProcessTask(PartitionedHandler<ProcessTask> service) {",
+        "    this.service = service;",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    write(
+      "src/main/java/com/example/app/ScheduleConfig.java",
+      [
+        "package com.example.app;",
+        "",
+        "import com.example.core.context.PartitionedHandler;",
+        "",
+        "public class ScheduleConfig {",
+        "  PartitionedHandler<ProcessTask> calculationService;",
+        "}",
+      ].join("\n"),
+    );
+    write(
+      "src/test/java/com/example/app/ServiceTest.java",
+      [
+        "package com.example.app;",
+        "",
+        "import com.example.core.context.PartitionedHandler;",
+        "",
+        "public class ServiceTest {",
+        "  public void testHandler() {",
+        "    PartitionedHandler<ProcessTask> service = mock(PartitionedHandler.class);",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+
+    const indexer = new Indexer(getProjectConfig(root));
+    try {
+      await indexer.index();
+
+      const impactPaths = indexer.symbolRefStore
+        .getImpact("PartitionedHandler", 20)
+        .map((hit) => hit.file_path);
+      expect(impactPaths).toEqual(
+        expect.arrayContaining([
+          "src/main/java/com/example/app/ProcessTask.java",
+          "src/main/java/com/example/app/ScheduleConfig.java",
+          "src/test/java/com/example/app/ServiceTest.java",
+        ]),
+      );
+
+      const files = indexer.fileStore.getAll();
+      const handler = files.find((file) => file.path.endsWith("PartitionedHandler.java"));
+      const schedule = files.find((file) => file.path.endsWith("ScheduleConfig.java"));
+      expect(handler?.pagerank ?? 0).toBeGreaterThan(schedule?.pagerank ?? 0);
+    } finally {
+      indexer.close();
+    }
+  });
+});

--- a/src/indexer/parser-java.test.ts
+++ b/src/indexer/parser-java.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseFile } from "./parser.js";
+
+describe("parseFile — issue #83 Java imports", () => {
+  it("extracts short imported names from Java imports", () => {
+    const result = parseFile(
+      [
+        "import com.example.core.context.PartitionedHandler;",
+        "import static com.example.core.context.PartitionedHandler.create;",
+        "public class ScheduleConfig {}",
+      ].join("\n"),
+      "java",
+    );
+
+    expect(result.imports).toEqual([
+      {
+        source: "com.example.core.context.PartitionedHandler",
+        names: ["PartitionedHandler"],
+        isRelative: false,
+      },
+      {
+        source: "com.example.core.context.PartitionedHandler",
+        names: ["create"],
+        isRelative: false,
+      },
+    ]);
+  });
+});

--- a/src/indexer/parsers/java.ts
+++ b/src/indexer/parsers/java.ts
@@ -9,8 +9,18 @@ export function parseJava(content: string, lines: string[]): ParseResult {
     const trimmed = lines[i].trimStart();
 
     if (/^import\s+/.test(trimmed)) {
-      const source = trimmed.match(/import\s+(?:static\s+)?([^;]+)/)?.[1] || "";
-      imports.push({ source, names: [], isRelative: false });
+      const match = trimmed.match(/^import\s+(static\s+)?([^;]+);?/);
+      if (match) {
+        const isStatic = Boolean(match[1]);
+        const rawSource = match[2].trim();
+        const parts = rawSource.split(".");
+        const importedName = parts[parts.length - 1] || "";
+        const classIndex = isStatic ? parts.length - 2 : parts.length - 1;
+        const className = parts[classIndex] || "";
+        const source = isStatic ? parts.slice(0, classIndex + 1).join(".") : rawSource;
+        const name = importedName === "*" ? null : isStatic ? importedName : className;
+        imports.push({ source, names: name ? [name] : [], isRelative: false });
+      }
       continue;
     }
 

--- a/src/indexer/symbol-extractor.test.ts
+++ b/src/indexer/symbol-extractor.test.ts
@@ -99,3 +99,26 @@ describe("extractReferences — issue #13 regression", () => {
     expect(refs.some((r) => r.name === "bar")).toBe(true);
   });
 });
+
+describe("extractReferences — issue #83 Java type usage regression", () => {
+  it("records Java type-only usages for impact analysis", () => {
+    const refs = extractReferences(
+      [
+        "import com.example.core.context.PartitionedHandler;",
+        "public class ScheduleConfig {",
+        "  @Nullable PartitionedHandler<ProcessTask> calculationService;",
+        "  private final PartitionedHandler<ProcessTask> service;",
+        "  public class Worker extends PartitionedHandler<Action> {",
+        "  public class WorkerCallback implements PartitionedHandler.Callback<Message> {",
+        "  PartitionedHandler<ProcessTask> handler = mock(PartitionedHandler.class);",
+        "}",
+      ].join("\n"),
+      "ScheduleConfig",
+    );
+
+    expect(refs.filter((ref) => ref.name === "PartitionedHandler").map((ref) => ref.line)).toEqual([
+      0, 2, 3, 4, 5, 6,
+    ]);
+    expect(refs.some((ref) => ref.name === "ScheduleConfig")).toBe(false);
+  });
+});

--- a/src/indexer/symbol-extractor.ts
+++ b/src/indexer/symbol-extractor.ts
@@ -2,8 +2,9 @@
  * Extract symbol references from a chunk's content.
  *
  * This is a cheap, language-agnostic heuristic: find identifier-shaped tokens
- * that look like function calls (`foo(`) or class instantiations (`new Foo`).
- * We skip language keywords and self-references.
+ * that look like function calls (`foo(`), class instantiations (`new Foo`),
+ * decorators, JSX components, or Java/C#-style type usages. We skip language
+ * keywords and self-references.
  *
  * It's not a type resolver — matches are by name. Multiple functions with the
  * same name across files will all appear as "impacted" when queried. That's
@@ -22,10 +23,15 @@ const KEYWORDS = new Set([
   "try", "catch", "finally", "throw", "throws", "raise", "except", "with",
   "pub", "use", "mod", "crate", "mut", "ref", "extern", "unsafe",
   "let", "end", "begin", "module", "object", "case", "match", "when", "then",
+  "package", "extends", "implements", "record",
   "print", "println", "echo", "log", "require", "include", "namespace",
   // Common built-ins (avoid false positives)
   "console", "process", "Array", "Object", "String", "Number", "Boolean",
   "Map", "Set", "Promise", "Error", "Date", "Math", "JSON", "RegExp",
+  "Integer", "Long", "Double", "Float", "Short", "Byte", "Character", "Void",
+  "List", "ArrayList", "LinkedList", "HashMap", "HashSet", "Optional",
+  "Stream", "Consumer", "Supplier", "Function", "Runnable", "Thread",
+  "Exception", "RuntimeException", "Override", "Deprecated", "SuppressWarnings",
   "length", "push", "pop", "map", "filter", "reduce", "forEach", "slice",
   "split", "join", "concat", "includes", "indexOf", "find", "some", "every",
 ]);
@@ -49,6 +55,8 @@ const JSX_RE = /<([A-Z][a-zA-Z0-9_]{2,})\b/g;
 const CALLBACK_RE = /(?:,\s*|\(\s*|,\s*['"][^'"]*['"]\s*,\s*)([a-z_][a-zA-Z0-9_]{2,})\s*[,)]/g;
 // Decorator usage: @MyDecorator
 const DECORATOR_RE = /@([A-Z][a-zA-Z0-9_]{2,})/g;
+// Uppercase tokens that may be type references in Java/C#/Kotlin-style syntax.
+const TYPE_TOKEN_RE = /\b([A-Z][a-zA-Z0-9_]{2,})\b/g;
 
 /**
  * Extract referenced symbol names from a chunk's body.
@@ -129,9 +137,51 @@ export function extractReferences(
       seenOnLine.add(name);
       refs.push({ name, line: i });
     }
+
+    // Type references: Java fields/params/generics/imports/class literals.
+    TYPE_TOKEN_RE.lastIndex = 0;
+    while ((m = TYPE_TOKEN_RE.exec(stripped)) !== null) {
+      const name = m[1];
+      if (
+        name === selfName ||
+        KEYWORDS.has(name) ||
+        COMMON_BUILTINS.has(name) ||
+        seenOnLine.has(name) ||
+        !isLikelyTypeUsage(stripped, m.index, name)
+      ) continue;
+      seenOnLine.add(name);
+      refs.push({ name, line: i });
+    }
   }
 
   return refs;
+}
+
+function isLikelyTypeUsage(line: string, index: number, name: string): boolean {
+  const before = line.slice(0, index);
+  const after = line.slice(index + name.length);
+
+  if (/\b(?:class|interface|enum|record|@interface)\s+$/.test(before)) {
+    return false;
+  }
+
+  if (/\bimport\s+(?:static\s+)?(?:[a-z_][a-zA-Z0-9_]*\.)+$/.test(before)) {
+    return true;
+  }
+
+  if (/^\s*(?:<|\[\]|\.\s*(?:class\b|[A-Z][a-zA-Z0-9_]*\b))/.test(after)) {
+    return true;
+  }
+
+  if (/^\s+[a-z_][a-zA-Z0-9_]*\b/.test(after)) {
+    return true;
+  }
+
+  if (/\b(?:extends|implements|throws|instanceof|catch)\s+(?:[\w$.,<>\s?&]*\s)?$/.test(before)) {
+    return true;
+  }
+
+  return /[<,]\s*$/.test(before) && /^\s*(?:[>,?&]|extends\b|super\b)/.test(after);
 }
 
 /**


### PR DESCRIPTION
## Summary
- record Java type-position references such as generics, fields, inheritance, imports, and .class literals for impact analysis
- parse Java import names, including static imports normalized to the owning class
- resolve dotted JVM package imports to local source files so Java codebases produce PageRank edges

Fixes #83

## Verification
- npm test -- --run src/indexer/symbol-extractor.test.ts src/indexer/parser-java.test.ts src/indexer/indexer-java.test.ts
- npm run build
- npm run lint
- npm test